### PR TITLE
 return domain_id from define_domains and mpp cleanup

### DIFF
--- a/pyfms/__init__.py
+++ b/pyfms/__init__.py
@@ -2,13 +2,8 @@ from .py_data_override.py_data_override import pyDataOverride
 from .py_diag_manager.pyfms_diag_manager import DiagManager
 from .py_field_manager.py_field_manager import FieldTable
 from .py_horiz_interp.py_horiz_interp import HorizInterp
-from .py_mpp.py_mpp import pyFMS_mpp
-from .py_mpp.py_mpp_domains import (
-    pyDomain,
-    pyDomainData,
-    pyFMS_mpp_domains,
-    pyNestDomain,
-)
+from .py_mpp.py_mpp import mpp
+from .py_mpp.py_mpp_domains import mpp_domains, pyDomain
 from .pyfms import pyFMS
 from .pyfms_utils import data_handling
 from .pyfms_utils.constants import constants

--- a/pyfms/py_diag_manager/pyfms_diag_manager.py
+++ b/pyfms/py_diag_manager/pyfms_diag_manager.py
@@ -215,6 +215,7 @@ class DiagManager:
         axis_data: NDArray,
         units: str,
         cart_name: str,
+        domain_id: int = None,
         long_name: str = None,
         set_name: str = None,
         direction: int = None,
@@ -233,6 +234,7 @@ class DiagManager:
         naxis_data_c, naxis_data_t = setscalar_Cint32(axis_data.size)
         units_c, units_t = set_Cchar(units)
         cart_name_c, cart_name_t = set_Cchar(cart_name)
+        domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
         long_name_c, long_name_t = set_Cchar(long_name)
         set_name_c, set_name_t = set_Cchar(set_name)
         direction_c, direction_t = setscalar_Cint32(direction)
@@ -258,6 +260,7 @@ class DiagManager:
             axis_data_t,
             units_t,
             cart_name_t,
+            domain_id_t,
             long_name_t,
             direction_t,
             set_name_t,
@@ -276,6 +279,7 @@ class DiagManager:
             axis_data_p,
             units_c,
             cart_name_c,
+            domain_id_c,
             long_name_c,
             direction_c,
             set_name_c,

--- a/pyfms/py_mpp/py_mpp_domains.py
+++ b/pyfms/py_mpp/py_mpp_domains.py
@@ -1,5 +1,4 @@
 import ctypes
-from typing import Optional
 
 import numpy as np
 from numpy.typing import NDArray
@@ -15,37 +14,88 @@ from ..pyfms_utils.data_handling import (
 )
 
 
-class pyDomainData:
+class pyDomain:
+
     def __init__(
         self,
-        xbegin=0,
-        xend=0,
-        ybegin=0,
-        yend=0,
-        xsize=0,
-        xmax_size=0,
-        ysize=0,
-        ymax_size=0,
-        x_is_global=False,
-        y_is_global=False,
-        tile_count=0,
+        domain_id: int = None,
+        isc: int = None,
+        jsc: int = None,
+        iec: int = None,
+        jec: int = None,
+        isd: int = None,
+        jsd: int = None,
+        ied: int = None,
+        jed: int = None,
+        tile: int = None,
+        layout: list[int] = None,
     ):
-        self.xbegin = ctypes.c_int(xbegin)
-        self.xend = ctypes.c_int(xend)
-        self.ybegin = ctypes.c_int(ybegin)
-        self.yend = ctypes.c_int(yend)
-        self.xsize = ctypes.c_int(xsize)
-        self.xmax_size = ctypes.c_int(xmax_size)
-        self.ysize = ctypes.c_int(ysize)
-        self.ymax_size = ctypes.c_int(ymax_size)
-        self.x_is_global = ctypes.c_bool(x_is_global)
-        self.y_is_global = ctypes.c_bool(y_is_global)
-        self.tile_count = ctypes.c_int(tile_count)
+        self.domain_id = domain_id
+        self.isc = isc
+        self.jsc = jsc
+        self.iec = iec
+        self.jec = jec
+        self.isd = isd
+        self.jsd = jsd
+        self.ied = ied
+        self.jed = jed
+        self.tile = tile
+        self.layout = layout
 
 
-class pyFMS_mpp_domains:
+class mpp_domains:
+
+    GLOBAL_DATA_DOMAIN: int = None
+    BGRID_NE: int = None
+    CGRID_NE: int = None
+    DGRID_NE: int = None
+    AGRID: int = None
+    FOLD_SOUTH_EDGE: int = None
+    FOLD_WEST_EDGE: int = None
+    FOLD_EAST_EDGE: int = None
+    CYCLIC_GLOBAL_DOMAIN: int = None
+    NUPDATE: int = None
+    EUPDATE: int = None
+    XUPDATE: int = None
+    YUPDATE: int = None
+    NORTH: int = None
+    NORTH_EAST: int = None
+    EAST: int = None
+    SOUTH_EAST: int = None
+    CORNER: int = None
+    CENTER: int = None
+    SOUTH: int = None
+    SOUTH_WEST: int = None
+
     def __init__(self, cFMS: ctypes.CDLL = None):
         self.cFMS = cFMS
+        self.GLOBAL_DATA_DOMAIN = ctypes.c_int.in_dll(
+            self.cFMS, "GLOBAL_DATA_DOMAIN"
+        ).value
+        self.BGRID_NE = ctypes.c_int.in_dll(self.cFMS, "BGRID_NE").value
+        self.CGRID_NE = ctypes.c_int.in_dll(self.cFMS, "CGRID_NE").value
+        self.DGRID_NE = ctypes.c_int.in_dll(self.cFMS, "DGRID_NE").value
+        self.AGRID = ctypes.c_int.in_dll(self.cFMS, "AGRID").value
+        self.FOLD_SOUTH_EDGE = ctypes.c_int.in_dll(self.cFMS, "FOLD_SOUTH_EDGE").value
+        self.FOLD_WEST_EDGE = ctypes.c_int.in_dll(self.cFMS, "FOLD_WEST_EDGE").value
+        self.FOLD_EAST_EDGE = ctypes.c_int.in_dll(self.cFMS, "FOLD_EAST_EDGE").value
+        self.CYCLIC_GLOBAL_DOMAIN = ctypes.c_int.in_dll(
+            self.cFMS, "CYCLIC_GLOBAL_DOMAIN"
+        ).value
+        self.NUPDATE = ctypes.c_int.in_dll(self.cFMS, "NUPDATE").value
+        self.EUPDATE = ctypes.c_int.in_dll(self.cFMS, "EUPDATE").value
+        self.XUPDATE = ctypes.c_int.in_dll(self.cFMS, "XUPDATE").value
+        self.YUPDATE = ctypes.c_int.in_dll(self.cFMS, "YUPDATE").value
+        self.NORTH = ctypes.c_int.in_dll(self.cFMS, "NORTH").value
+        self.NORTH_EAST = ctypes.c_int.in_dll(self.cFMS, "NORTH_EAST").value
+        self.EAST = ctypes.c_int.in_dll(self.cFMS, "EAST").value
+        self.SOUTH_EAST = ctypes.c_int.in_dll(self.cFMS, "SOUTH_EAST").value
+        self.CORNER = ctypes.c_int.in_dll(self.cFMS, "CORNER").value
+        self.CENTER = ctypes.c_int.in_dll(self.cFMS, "CENTER").value
+        self.SOUTH = ctypes.c_int.in_dll(self.cFMS, "SOUTH").value
+        self.SOUTH_WEST = ctypes.c_int.in_dll(self.cFMS, "SOUTH_WEST").value
+        self.WEST = ctypes.c_int.in_dll(self.cFMS, "WEST").value
+        self.NORTH_WEST = ctypes.c_int.in_dll(self.cFMS, "NORTH_WEST").value
 
     """
     Subroutine: define_domains
@@ -63,49 +113,61 @@ class pyFMS_mpp_domains:
         self,
         global_indices: list[int],
         layout: list[int],
-        domain_id: Optional[int] = None,
-        pelist: Optional[NDArray] = None,
-        xflags: Optional[int] = None,
-        yflags: Optional[int] = None,
-        xhalo: Optional[int] = None,
-        yhalo: Optional[int] = None,
-        xextent: Optional[NDArray] = None,
-        yextent: Optional[NDArray] = None,
-        maskmap: Optional[NDArray[np.bool_]] = None,
-        name: Optional[str] = None,
-        symmetry: Optional[bool] = None,
-        memory_size: Optional[NDArray] = None,
-        whalo: Optional[int] = None,
-        ehalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-        nhalo: Optional[int] = None,
-        is_mosaic: Optional[bool] = None,
-        tile_count: Optional[int] = None,
-        tile_id: Optional[int] = None,
-        complete: Optional[bool] = None,
-        x_cyclic_offset: Optional[int] = None,
-        y_cyclic_offset: Optional[int] = None,
-    ):
+        pelist: list[int] = None,
+        xflags: int = None,
+        yflags: int = None,
+        xhalo: int = None,
+        yhalo: int = None,
+        xextent: list[int] = None,
+        yextent: list[int] = None,
+        maskmap: list[list[np.bool_]] = None,
+        name: str = None,
+        symmetry: bool = None,
+        memory_size: list[int] = None,
+        whalo: int = None,
+        ehalo: int = None,
+        shalo: int = None,
+        nhalo: int = None,
+        is_mosaic: bool = None,
+        tile_count: int = None,
+        tile_id: int = None,
+        complete: bool = None,
+        x_cyclic_offset: int = None,
+        y_cyclic_offset: int = None,
+    ) -> pyDomain:
 
         _cfms_define_domains = self.cFMS.cFMS_define_domains
 
         global_indices_arr = np.array(global_indices, dtype=np.int32)
         layout_arr = np.array(layout, dtype=np.int32)
+        xextent_arr = np.array(xextent, dtype=np.int32) if xextent is not None else None
+        yextent_arr = np.array(yextent, dtype=np.int32) if yextent is not None else None
+        maskmap_arr = np.array(maskmap, dtype=np.bool_) if maskmap is not None else None
+        memory_size_arr = (
+            np.array(memory_size, dtype=np.int32) if memory_size is not None else None
+        )
+
+        if pelist is not None:
+            pelist_arr = np.array(pelist, dtype=np.int32)
+            npelist = len(pelist)
+        else:
+            pelist_arr = None
+            npelist = 1
 
         global_indices_p, global_indices_t = setarray_Cint32(global_indices_arr)
         layout_p, layout_t = setarray_Cint32(layout_arr)
-        domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
-        pelist_p, pelist_t = setarray_Cint32(pelist)
+        npelist_c, npelist_t = setscalar_Cint32(npelist)
+        pelist_p, pelist_t = setarray_Cint32(pelist_arr)
         xflags_c, xflags_t = setscalar_Cint32(xflags)
         yflags_c, yflags_t = setscalar_Cint32(yflags)
         xhalo_c, xhalo_t = setscalar_Cint32(xhalo)
         yhalo_c, yhalo_t = setscalar_Cint32(yhalo)
-        xextent_p, xextent_t = setarray_Cint32(xextent)
-        yextent_p, yextent_t = setarray_Cint32(yextent)
-        maskmap_p, maskmap_t = setarray_Cbool(maskmap)
+        xextent_p, xextent_t = setarray_Cint32(xextent_arr)
+        yextent_p, yextent_t = setarray_Cint32(yextent_arr)
+        maskmap_p, maskmap_t = setarray_Cbool(maskmap_arr)
         name_c, name_t = set_Cchar(name)
         symmetry_c, symmetry_t = setscalar_Cbool(symmetry)
-        memory_size_p, memory_size_t = setarray_Cint32(memory_size)
+        memory_size_p, memory_size_t = setarray_Cint32(memory_size_arr)
         whalo_c, whalo_t = setscalar_Cint32(whalo)
         ehalo_c, ehalo_t = setscalar_Cint32(ehalo)
         shalo_c, shalo_t = setscalar_Cint32(shalo)
@@ -120,7 +182,7 @@ class pyFMS_mpp_domains:
         _cfms_define_domains.argtypes = [
             global_indices_t,
             layout_t,
-            domain_id_t,
+            npelist_t,
             pelist_t,
             xflags_t,
             yflags_t,
@@ -144,12 +206,12 @@ class pyFMS_mpp_domains:
             y_cyclic_offset_t,
         ]
 
-        _cfms_define_domains.restype = None
+        _cfms_define_domains.restype = ctypes.c_int
 
-        _cfms_define_domains(
+        domain_id = _cfms_define_domains(
             global_indices_p,
             layout_p,
-            domain_id_c,
+            npelist_c,
             pelist_p,
             xflags_c,
             yflags_c,
@@ -173,6 +235,8 @@ class pyFMS_mpp_domains:
             y_cyclic_offset_c,
         )
 
+        return pyDomain(domain_id=domain_id, layout=layout, tile=tile_id)
+
     """
     Subroutine: define_io_domains
 
@@ -181,7 +245,7 @@ class pyFMS_mpp_domains:
     Returns: No return
     """
 
-    def define_io_domain(self, io_layout: list[int], domain_id: Optional[int] = None):
+    def define_io_domain(self, io_layout: list[int], domain_id: int):
         _cfms_define_io_domain = self.cFMS.cFMS_define_io_domain
 
         io_layout_arr = np.array(io_layout, dtype=np.int32)
@@ -237,36 +301,45 @@ class pyFMS_mpp_domains:
         self,
         num_nest: int,
         ntiles: int,
-        nest_level: NDArray,
-        tile_fine: NDArray,
-        tile_coarse: NDArray,
-        istart_coarse: NDArray,
-        icount_coarse: NDArray,
-        jstart_coarse: NDArray,
-        jcount_coarse: NDArray,
-        npes_nest_tile: NDArray,
-        x_refine: NDArray,
-        y_refine: NDArray,
-        nest_domain_id: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        extra_halo: Optional[int] = None,
-        name: Optional[str] = None,
-    ):
+        nest_level: list[int],
+        tile_fine: list[int],
+        tile_coarse: list[int],
+        istart_coarse: list[int],
+        icount_coarse: list[int],
+        jstart_coarse: list[int],
+        jcount_coarse: list[int],
+        npes_nest_tile: list[int],
+        x_refine: list[int],
+        y_refine: list[int],
+        domain_id: int,
+        extra_halo: int = None,
+        name: str = None,
+    ) -> int:
         _cfms_define_nest_domain = self.cFMS.cFMS_define_nest_domains
+
+        nest_level_arr = np.array(nest_level, dtype=np.int32)
+        tile_fine_arr = np.array(tile_fine, dtype=np.int32)
+        tile_coarse_arr = np.array(tile_coarse, dtype=np.int32)
+        istart_coarse_arr = np.array(istart_coarse, dtype=np.int32)
+        jstart_coarse_arr = np.array(jstart_coarse, dtype=np.int32)
+        icount_coarse_arr = np.array(icount_coarse, dtype=np.int32)
+        jcount_coarse_arr = np.array(jcount_coarse, dtype=np.int32)
+        npes_nest_tile_arr = np.array(npes_nest_tile, dtype=np.int32)
+        x_refine_arr = np.array(x_refine, dtype=np.int32)
+        y_refine_arr = np.array(y_refine, dtype=np.int32)
 
         num_nest_p, num_nest_t = setscalar_Cint32(num_nest)
         ntiles_c, ntiles_t = setscalar_Cint32(ntiles)
-        nest_level_p, nest_level_t = setarray_Cint32(nest_level)
-        tile_fine_p, tile_fine_t = setarray_Cint32(tile_fine)
-        tile_coarse_p, tile_coarse_t = setarray_Cint32(tile_coarse)
-        istart_coarse_p, istart_coarse_t = setarray_Cint32(istart_coarse)
-        icount_coarse_p, icount_coarse_t = setarray_Cint32(icount_coarse)
-        jstart_coarse_p, jstart_coarse_t = setarray_Cint32(jstart_coarse)
-        jcount_coarse_p, jcount_coarse_t = setarray_Cint32(jcount_coarse)
-        npes_nest_tile_p, npes_nest_tile_t = setarray_Cint32(npes_nest_tile)
-        x_refine_p, x_refine_t = setarray_Cint32(x_refine)
-        y_refine_p, y_refine_t = setarray_Cint32(y_refine)
-        nest_domain_id_c, nest_domain_id_t = setscalar_Cint32(nest_domain_id)
+        nest_level_p, nest_level_t = setarray_Cint32(nest_level_arr)
+        tile_fine_p, tile_fine_t = setarray_Cint32(tile_fine_arr)
+        tile_coarse_p, tile_coarse_t = setarray_Cint32(tile_coarse_arr)
+        istart_coarse_p, istart_coarse_t = setarray_Cint32(istart_coarse_arr)
+        icount_coarse_p, icount_coarse_t = setarray_Cint32(icount_coarse_arr)
+        jstart_coarse_p, jstart_coarse_t = setarray_Cint32(jstart_coarse_arr)
+        jcount_coarse_p, jcount_coarse_t = setarray_Cint32(jcount_coarse_arr)
+        npes_nest_tile_p, npes_nest_tile_t = setarray_Cint32(npes_nest_tile_arr)
+        x_refine_p, x_refine_t = setarray_Cint32(x_refine_arr)
+        y_refine_p, y_refine_t = setarray_Cint32(y_refine_arr)
         domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
         extra_halo_c, extra_halo_t = setscalar_Cint32(extra_halo)
         name_p, name_t = set_Cchar(name)
@@ -284,14 +357,13 @@ class pyFMS_mpp_domains:
             npes_nest_tile_t,
             x_refine_t,
             y_refine_t,
-            nest_domain_id_t,
             domain_id_t,
             extra_halo_t,
             name_t,
         ]
-        _cfms_define_nest_domain.restype = None
+        _cfms_define_nest_domain.restype = ctypes.c_int
 
-        _cfms_define_nest_domain(
+        return _cfms_define_nest_domain(
             num_nest_p,
             ntiles_c,
             nest_level_p,
@@ -304,7 +376,6 @@ class pyFMS_mpp_domains:
             npes_nest_tile_p,
             x_refine_p,
             y_refine_p,
-            nest_domain_id_c,
             domain_id_c,
             extra_halo_c,
             name_p,
@@ -319,7 +390,7 @@ class pyFMS_mpp_domains:
     Returns: Boolean
     """
 
-    def domain_is_initialized(self, domain_id: Optional[int] = None) -> bool:
+    def domain_is_initialized(self, domain_id: int) -> bool:
         _cfms_domain_is_initialized = self.cFMS.cFMS_domain_is_initialized
 
         domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
@@ -345,76 +416,12 @@ class pyFMS_mpp_domains:
 
     def get_compute_domain(
         self,
-        domain_data: pyDomainData,
-        domain_id: Optional[int] = None,
-        position: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-    ):
-
-        _cfms_get_compute_domain = self.cFMS.cFMS_get_compute_domain
-
-        domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
-        xbegin_c, xbegin_t = setscalar_Cint32(domain_data.xbegin)
-        xend_c, xend_t = setscalar_Cint32(domain_data.xend)
-        ybegin_c, ybegin_t = setscalar_Cint32(domain_data.ybegin)
-        yend_c, yend_t = setscalar_Cint32(domain_data.yend)
-        xsize_c, xsize_t = setscalar_Cint32(domain_data.xsize)
-        xmax_size_c, xmax_size_t = setscalar_Cint32(domain_data.xmax_size)
-        ysize_c, ysize_t = setscalar_Cint32(domain_data.ysize)
-        ymax_size_c, ymax_size_t = setscalar_Cint32(domain_data.ymax_size)
-        x_is_global_c, x_is_global_t = setscalar_Cbool(domain_data.x_is_global)
-        y_is_global_c, y_is_global_t = setscalar_Cbool(domain_data.y_is_global)
-        tile_count_c, tile_count_t = setscalar_Cint32(domain_data.tile_count)
-        position_c, position_t = setscalar_Cint32(position)
-        whalo_c, whalo_t = setscalar_Cint32(whalo)
-        shalo_c, shalo_t = setscalar_Cint32(shalo)
-
-        _cfms_get_compute_domain.argtypes = [
-            domain_id_t,
-            xbegin_t,
-            xend_t,
-            ybegin_t,
-            yend_t,
-            xsize_t,
-            xmax_size_t,
-            ysize_t,
-            ymax_size_t,
-            x_is_global_t,
-            y_is_global_t,
-            tile_count_t,
-            position_t,
-            whalo_t,
-            shalo_t,
-        ]
-        _cfms_get_compute_domain.restype = None
-
-        _cfms_get_compute_domain(
-            domain_id_c,
-            xbegin_c,
-            xend_c,
-            ybegin_c,
-            yend_c,
-            xsize_c,
-            xmax_size_c,
-            ysize_c,
-            ymax_size_c,
-            x_is_global_c,
-            y_is_global_c,
-            tile_count_c,
-            position_c,
-            whalo_c,
-            shalo_c,
-        )
-
-    def get_compute_domain2(
-        self,
-        domain_id: int | None = None,
-        position: int | None = None,
-        tile_count: int | None = None,
-        whalo: int | None = None,
-        shalo: int | None = None,
-    ):
+        domain_id: int,
+        position: int = None,
+        tile_count: int = None,
+        whalo: int = None,
+        shalo: int = None,
+    ) -> dict:
 
         _cfms_get_compute_domain = self.cFMS.cFMS_get_compute_domain
 
@@ -449,7 +456,7 @@ class pyFMS_mpp_domains:
         y_is_global_c = y_is_global_t(default_b)
         domain_id_c = domain_id_t(domain_id) if domain_id is not None else None
         tile_count_c = tile_count_t(tile_count) if tile_count is not None else None
-        position_c = position_t(position) if tile_count is not None else None
+        position_c = position_t(position) if position is not None else None
         whalo_c = whalo_t(whalo) if whalo is not None else None
         shalo_c = shalo_t(shalo) if shalo is not None else None
 
@@ -521,47 +528,67 @@ class pyFMS_mpp_domains:
 
     def get_data_domain(
         self,
-        domain_data: pyDomainData,
-        domain_id: Optional[int] = None,
-        position: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-    ):
+        domain_id: int,
+        position: int = None,
+        tile_count: int = None,
+        whalo: int = None,
+        shalo: int = None,
+    ) -> dict:
         _cfms_get_data_domain = self.cFMS.cFMS_get_data_domain
 
-        domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
-        xbegin_c, xbegin_t = setscalar_Cint32(domain_data.xbegin)
-        xend_c, xend_t = setscalar_Cint32(domain_data.xend)
-        ybegin_c, ybegin_t = setscalar_Cint32(domain_data.ybegin)
-        yend_c, yend_t = setscalar_Cint32(domain_data.yend)
-        xsize_c, xsize_t = setscalar_Cint32(domain_data.xsize)
-        xmax_size_c, xmax_size_t = setscalar_Cint32(domain_data.xmax_size)
-        ysize_c, ysize_t = setscalar_Cint32(domain_data.ysize)
-        ymax_size_c, ymax_size_t = setscalar_Cint32(domain_data.ymax_size)
-        x_is_global_c, x_is_global_t = setscalar_Cbool(domain_data.x_is_global)
-        y_is_global_c, y_is_global_t = setscalar_Cbool(domain_data.y_is_global)
-        tile_count_c, tile_count_t = setscalar_Cint32(domain_data.tile_count)
-        position_c, position_t = setscalar_Cint32(position)
-        whalo_c, whalo_t = setscalar_Cint32(whalo)
-        shalo_c, shalo_t = setscalar_Cint32(shalo)
+        default_i = 0
+        default_b = False
+
+        domain_id_t = ctypes.c_int
+        xbegin_t = ctypes.c_int
+        xend_t = ctypes.c_int
+        ybegin_t = ctypes.c_int
+        yend_t = ctypes.c_int
+        xsize_t = ctypes.c_int
+        xmax_size_t = ctypes.c_int
+        ysize_t = ctypes.c_int
+        ymax_size_t = ctypes.c_int
+        x_is_global_t = ctypes.c_bool
+        y_is_global_t = ctypes.c_bool
+        tile_count_t = ctypes.c_int
+        position_t = ctypes.c_int
+        whalo_t = ctypes.c_int
+        shalo_t = ctypes.c_int
+
+        xbegin_c = xbegin_t(default_i)
+        xend_c = xend_t(default_i)
+        ybegin_c = ybegin_t(default_i)
+        yend_c = yend_t(default_i)
+        xsize_c = xsize_t(default_i)
+        xmax_size_c = xmax_size_t(default_i)
+        ysize_c = ysize_t(default_i)
+        ymax_size_c = ymax_size_t(default_i)
+        x_is_global_c = x_is_global_t(default_b)
+        y_is_global_c = y_is_global_t(default_b)
+        domain_id_c = domain_id_t(domain_id) if domain_id is not None else None
+        tile_count_c = tile_count_t(tile_count) if tile_count is not None else None
+        position_c = position_t(position) if position is not None else None
+        whalo_c = whalo_t(whalo) if whalo is not None else None
+        shalo_c = shalo_t(shalo) if shalo is not None else None
 
         _cfms_get_data_domain.argtypes = [
-            domain_id_t,
-            xbegin_t,
-            xend_t,
-            ybegin_t,
-            yend_t,
-            xsize_t,
-            xmax_size_t,
-            ysize_t,
-            ymax_size_t,
-            x_is_global_t,
-            y_is_global_t,
-            tile_count_t,
-            position_t,
-            whalo_t,
-            shalo_t,
+            ctypes.POINTER(domain_id_t),
+            ctypes.POINTER(xbegin_t),
+            ctypes.POINTER(xend_t),
+            ctypes.POINTER(ybegin_t),
+            ctypes.POINTER(yend_t),
+            ctypes.POINTER(xsize_t),
+            ctypes.POINTER(xmax_size_t),
+            ctypes.POINTER(ysize_t),
+            ctypes.POINTER(ymax_size_t),
+            ctypes.POINTER(x_is_global_t),
+            ctypes.POINTER(y_is_global_t),
+            ctypes.POINTER(tile_count_t),
+            ctypes.POINTER(position_t),
+            ctypes.POINTER(whalo_t),
+            ctypes.POINTER(shalo_t),
         ]
+
         _cfms_get_data_domain.restype = None
 
         _cfms_get_data_domain(
@@ -582,6 +609,20 @@ class pyFMS_mpp_domains:
             shalo_c,
         )
 
+        return dict(
+            domain_id=domain_id_c.value,
+            xbegin=xbegin_c.value,
+            ybegin=ybegin_c.value,
+            xend=xend_c.value,
+            yend=yend_c.value,
+            xsize=xsize_c.value,
+            ysize=ysize_c.value,
+            xmax_size=xmax_size_c.value,
+            ymax_size=ymax_size_c.value,
+            x_is_global=x_is_global_c.value,
+            y_is_global=y_is_global_c.value,
+        )
+
     """
     Subroutine: get_domain_name
 
@@ -593,7 +634,7 @@ class pyFMS_mpp_domains:
     its value as well.
     """
 
-    def get_domain_name(self, domain_id: Optional[int] = None) -> str:
+    def get_domain_name(self, domain_id: int) -> str:
         _cfms_get_domain_name = self.cFMS.cFMS_get_domain_name
 
         domain_name = ""
@@ -616,7 +657,7 @@ class pyFMS_mpp_domains:
     Returns: NDArray with layout info
     """
 
-    def get_layout(self, domain_id: Optional[int] = None) -> NDArray:
+    def get_layout(self, domain_id: int) -> list[int]:
 
         layout = np.empty(shape=2, dtype=np.int32, order="C")
 
@@ -630,7 +671,7 @@ class pyFMS_mpp_domains:
 
         _cfms_get_layout(layout_p, domain_id_c)
 
-        return layout
+        return layout_p.tolist()
 
     """
     Subroutine: get_domain_pelist
@@ -638,7 +679,7 @@ class pyFMS_mpp_domains:
     Returns: NDArray containing pelist
     """
 
-    def get_domain_pelist(self, domain_id: Optional[int]) -> NDArray:
+    def get_domain_pelist(self, domain_id: int) -> list[int]:
 
         npes = ctypes.c_int.in_dll(self.cFMS, "cFMS_pelist_npes")
         pelist = np.empty(shape=npes.value, dtype=np.int32, order="C")
@@ -653,7 +694,7 @@ class pyFMS_mpp_domains:
 
         _cfms_get_domain_pelist(pelist_p, domain_id_c)
 
-        return pelist
+        return pelist_p.tolist()
 
     """
     Subroutine: set_compute_domain
@@ -674,18 +715,18 @@ class pyFMS_mpp_domains:
 
     def set_compute_domain(
         self,
-        xbegin: Optional[int] = None,
-        xend: Optional[int] = None,
-        ybegin: Optional[int] = None,
-        yend: Optional[int] = None,
-        xsize: Optional[int] = None,
-        ysize: Optional[int] = None,
-        x_is_global: Optional[bool] = None,
-        y_is_global: Optional[bool] = None,
-        tile_count: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
+        domain_id: int,
+        xbegin: int = None,
+        xend: int = None,
+        ybegin: int = None,
+        yend: int = None,
+        xsize: int = None,
+        ysize: int = None,
+        x_is_global: bool = None,
+        y_is_global: bool = None,
+        tile_count: int = None,
+        whalo: int = None,
+        shalo: int = None,
     ):
         _cfms_set_compute_domain = self.cFMS.cFMS_set_compute_domain
 
@@ -740,7 +781,7 @@ class pyFMS_mpp_domains:
     to domain_id
     """
 
-    def set_current_domain(self, domain_id: Optional[int] = None):
+    def set_current_domain(self, domain_id: int):
         _cfms_set_current_domain = self.cFMS.cFMS_set_current_domain
 
         domain_id_c, domain_id_t = setscalar_Cint32(domain_id)
@@ -757,7 +798,7 @@ class pyFMS_mpp_domains:
     to nest_domain_id
     """
 
-    def set_current_nest_domain(self, nest_domain_id: Optional[int] = None):
+    def set_current_nest_domain(self, nest_domain_id: int):
         _cfms_set_current_nest_domain = self.cFMS.cFMS_set_current_nest_domain
 
         nest_domain_id_c, nest_domain_id_t = setscalar_Cint32(nest_domain_id)
@@ -782,18 +823,18 @@ class pyFMS_mpp_domains:
 
     def set_data_domain(
         self,
-        xbegin: Optional[int] = None,
-        xend: Optional[int] = None,
-        ybegin: Optional[int] = None,
-        yend: Optional[int] = None,
-        xsize: Optional[int] = None,
-        ysize: Optional[int] = None,
-        x_is_global: Optional[bool] = None,
-        y_is_global: Optional[bool] = None,
-        tile_count: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
+        domain_id: int,
+        xbegin: int = None,
+        xend: int = None,
+        ybegin: int = None,
+        yend: int = None,
+        xsize: int = None,
+        ysize: int = None,
+        x_is_global: bool = None,
+        y_is_global: bool = None,
+        tile_count: int = None,
+        whalo: int = None,
+        shalo: int = None,
     ):
         _cfms_set_data_domain = self.cFMS.cFMS_set_data_domain
 
@@ -860,16 +901,16 @@ class pyFMS_mpp_domains:
 
     def set_global_domain(
         self,
-        xbegin: Optional[int] = None,
-        xend: Optional[int] = None,
-        ybegin: Optional[int] = None,
-        yend: Optional[int] = None,
-        xsize: Optional[int] = None,
-        ysize: Optional[int] = None,
-        tile_count: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
+        domain_id: int,
+        xbegin: int = None,
+        xend: int = None,
+        ybegin: int = None,
+        yend: int = None,
+        xsize: int = None,
+        ysize: int = None,
+        tile_count: int = None,
+        whalo: int = None,
+        shalo: int = None,
     ):
         _cfms_set_global_domain = self.cFMS.cFMS_set_global_domain
 
@@ -1031,260 +1072,4 @@ class pyFMS_mpp_domains:
             nhalo_c,
             name_c,
             tile_count_c,
-        )
-
-
-class pyDomain:
-    def __init__(
-        self,
-        mpp_domains_obj: pyFMS_mpp_domains,
-        global_indices: list[int],
-        layout: list[int],
-        domain_id: Optional[int] = None,
-        pelist: Optional[NDArray] = None,
-        xflags: Optional[int] = None,
-        yflags: Optional[int] = None,
-        xhalo: Optional[int] = None,
-        yhalo: Optional[int] = None,
-        xextent: Optional[NDArray] = None,
-        yextent: Optional[NDArray] = None,
-        maskmap: Optional[NDArray[np.bool_]] = None,
-        name: Optional[str] = None,
-        symmetry: Optional[bool] = None,
-        memory_size: Optional[NDArray] = None,
-        whalo: Optional[int] = None,
-        ehalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-        nhalo: Optional[int] = None,
-        is_mosaic: Optional[bool] = None,
-        tile_count: Optional[int] = None,
-        tile_id: Optional[int] = None,
-        complete: Optional[bool] = None,
-        x_cyclic_offset: Optional[int] = None,
-        y_cyclic_offset: Optional[int] = None,
-    ):
-        self.mpp_domains_obj = mpp_domains_obj
-        self.global_indices = global_indices
-        self.layout = layout
-        self.domain_id = domain_id
-        self.pelist = pelist
-        self.xflags = xflags
-        self.yflags = yflags
-        self.xhalo = xhalo
-        self.yhalo = yhalo
-        self.xextent = xextent
-        self.yextent = yextent
-        self.maskmap = maskmap
-        self.name = name
-        self.symmetry = symmetry
-        self.memory_size = memory_size
-        self.whalo = whalo
-        self.ehalo = ehalo
-        self.shalo = shalo
-        self.nhalo = nhalo
-        self.is_mosaic = is_mosaic
-        self.tile_count = tile_count
-        self.tile_id = tile_id
-        self.complete = complete
-        self.x_cyclic_offset = x_cyclic_offset
-        self.y_cyclic_offset = y_cyclic_offset
-        self.compute_domain = pyDomainData()
-        self.data_domain = pyDomainData()
-
-        self.mpp_domains_obj.define_domains(
-            global_indices=self.global_indices,
-            layout=self.layout,
-            domain_id=self.domain_id,
-            pelist=self.pelist,
-            xflags=self.xflags,
-            yflags=self.yflags,
-            xhalo=self.xhalo,
-            yhalo=self.yhalo,
-            xextent=self.xextent,
-            yextent=self.yextent,
-            maskmap=self.maskmap,
-            name=self.name,
-            symmetry=self.symmetry,
-            memory_size=self.memory_size,
-            whalo=self.whalo,
-            ehalo=self.ehalo,
-            shalo=self.shalo,
-            nhalo=self.nhalo,
-            is_mosaic=self.is_mosaic,
-            tile_count=self.tile_count,
-            tile_id=self.tile_id,
-            complete=self.complete,
-            x_cyclic_offset=self.x_cyclic_offset,
-            y_cyclic_offset=self.y_cyclic_offset,
-        )
-        self.mpp_domains_obj.get_compute_domain(
-            domain_data=self.compute_domain,
-            domain_id=self.domain_id,
-            whalo=self.whalo,
-            shalo=self.shalo,
-        )
-        self.mpp_domains_obj.get_data_domain(
-            domain_data=self.data_domain,
-            domain_id=self.domain_id,
-            whalo=self.whalo,
-            shalo=self.shalo,
-        )
-
-    def set_compute_domain(
-        self,
-        xbegin: Optional[int] = None,
-        xend: Optional[int] = None,
-        ybegin: Optional[int] = None,
-        yend: Optional[int] = None,
-        xsize: Optional[int] = None,
-        ysize: Optional[int] = None,
-        x_is_global: Optional[bool] = None,
-        y_is_global: Optional[bool] = None,
-        tile_count: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-    ):
-        self.mpp_domains_obj.set_compute_domain(
-            xbegin=xbegin,
-            xend=xend,
-            ybegin=ybegin,
-            yend=yend,
-            xsize=xsize,
-            ysize=ysize,
-            x_is_global=x_is_global,
-            y_is_global=y_is_global,
-            tile_count=tile_count,
-            domain_id=domain_id,
-            whalo=whalo,
-            shalo=shalo,
-        )
-
-        self.mpp_domains_obj.get_compute_domain(
-            domain_data=self.compute_domain,
-            domain_id=self.domain_id,
-            whalo=self.whalo,
-            shalo=self.shalo,
-        )
-
-    def set_data_domain(
-        self,
-        xbegin: Optional[int] = None,
-        xend: Optional[int] = None,
-        ybegin: Optional[int] = None,
-        yend: Optional[int] = None,
-        xsize: Optional[int] = None,
-        ysize: Optional[int] = None,
-        x_is_global: Optional[bool] = None,
-        y_is_global: Optional[bool] = None,
-        tile_count: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-    ):
-        self.mpp_domains_obj.set_data_domain(
-            xbegin=xbegin,
-            xend=xend,
-            ybegin=ybegin,
-            yend=yend,
-            xsize=xsize,
-            ysize=ysize,
-            x_is_global=x_is_global,
-            y_is_global=y_is_global,
-            tile_count=tile_count,
-            domain_id=domain_id,
-            whalo=whalo,
-            shalo=shalo,
-        )
-
-        self.mpp_domains_obj.get_data_domain(
-            domain_data=self.data_domain,
-            domain_id=self.domain_id,
-            whalo=self.whalo,
-            shalo=self.shalo,
-        )
-
-    def set_global_domain(
-        self,
-        xbegin: Optional[int] = None,
-        xend: Optional[int] = None,
-        ybegin: Optional[int] = None,
-        yend: Optional[int] = None,
-        xsize: Optional[int] = None,
-        ysize: Optional[int] = None,
-        tile_count: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        whalo: Optional[int] = None,
-        shalo: Optional[int] = None,
-    ):
-        self.mpp_domains_obj.set_global_domain(
-            xbegin=xbegin,
-            xend=xend,
-            ybegin=ybegin,
-            yend=yend,
-            xsize=xsize,
-            ysize=ysize,
-            tile_count=tile_count,
-            domain_id=domain_id,
-            whalo=whalo,
-            shalo=shalo,
-        )
-
-
-class pyNestDomain:
-    def __init__(
-        self,
-        mpp_domains_obj: pyFMS_mpp_domains,
-        num_nest: int,
-        ntiles: int,
-        nest_level: NDArray,
-        tile_fine: NDArray,
-        tile_coarse: NDArray,
-        istart_coarse: NDArray,
-        icount_coarse: NDArray,
-        jstart_coarse: NDArray,
-        jcount_coarse: NDArray,
-        npes_nest_tile: NDArray,
-        x_refine: NDArray,
-        y_refine: NDArray,
-        nest_domain_id: Optional[int] = None,
-        domain_id: Optional[int] = None,
-        extra_halo: Optional[int] = None,
-        name: Optional[str] = None,
-    ):
-        self.mpp_domains_obj = mpp_domains_obj
-        self.num_nest = num_nest
-        self.ntiles = ntiles
-        self.nest_level = nest_level
-        self.tile_fine = tile_fine
-        self.tile_coarse = tile_coarse
-        self.istart_coarse = istart_coarse
-        self.icount_coarse = icount_coarse
-        self.jstart_coarse = jstart_coarse
-        self.jcount_coarse = jcount_coarse
-        self.npes_nest_tile = npes_nest_tile
-        self.x_refine = x_refine
-        self.y_refine = y_refine
-        self.nest_domain_id = nest_domain_id
-        self.domain_id = domain_id
-        self.extra_halo = extra_halo
-        self.name = name
-
-        self.mpp_domains_obj.define_nest_domains(
-            num_nest=self.num_nest,
-            ntiles=self.ntiles,
-            nest_level=self.nest_level,
-            tile_fine=self.tile_fine,
-            tile_coarse=self.tile_coarse,
-            istart_coarse=self.istart_coarse,
-            icount_coarse=self.icount_coarse,
-            jstart_coarse=self.jstart_coarse,
-            jcount_coarse=self.jcount_coarse,
-            npes_nest_tile=self.npes_nest_tile,
-            x_refine=self.x_refine,
-            y_refine=self.y_refine,
-            nest_domain_id=self.nest_domain_id,
-            domain_id=self.domain_id,
-            extra_halo=self.extra_halo,
-            name=self.name,
         )

--- a/pyfms/pyfms.py
+++ b/pyfms/pyfms.py
@@ -107,19 +107,3 @@ class pyFMS:
             nnest_domain_c,
             calendar_type_c,
         )
-
-    """
-    Subroutine: pyfms_set_pelist_npes
-
-    This method is used to set a npes variable of the cFMS module it wraps
-    """
-
-    def set_pelist_npes(self, npes_in: int):
-        _cfms_set_npes = self.cFMS.cFMS_set_pelist_npes
-
-        npes_in_c, npes_in_t = setscalar_Cint32(npes_in)
-
-        _cfms_set_npes.argtypes = [npes_in_t]
-        _cfms_set_npes.restype = None
-
-        _cfms_set_npes(npes_in_c)

--- a/tests/py_data_override/test_data_override.py
+++ b/tests/py_data_override/test_data_override.py
@@ -12,10 +12,9 @@ def test_data_override():
 
     pyfmsobj = pyfms.pyFMS()
     cfms = pyfmsobj.cFMS
-    mpp = pyfms.pyFMS_mpp(cFMS=cfms)
-    mpp_domains = pyfms.pyFMS_mpp_domains(cFMS=cfms)
+    mpp_obj = pyfms.mpp(cFMS=cfms)
+    mpp_domains_obj = pyfms.mpp_domains(cFMS=cfms)
 
-    ocn_domain_id = 0
     nx = 360
     ny = 180
     nz = 5
@@ -27,22 +26,23 @@ def test_data_override():
     global_indices = np.array([0, nx - 1, 0, ny - 1], dtype=np.int32, order="C")
     layout = np.array([2, 3], dtype=np.int32, order="C")
 
-    mpp_domains.define_domains(
+    domain = mpp_domains_obj.define_domains(
         global_indices=global_indices,
         layout=layout,
         ehalo=ehalo,
         whalo=whalo,
         shalo=shalo,
         nhalo=nhalo,
-        domain_id=ocn_domain_id,
     )
 
-    compute_dict = mpp_domains.get_compute_domain2(domain_id=ocn_domain_id)
+    compute_dict = mpp_domains_obj.get_compute_domain(domain_id=domain.domain_id)
+
     xsize = compute_dict["xsize"]
     ysize = compute_dict["ysize"]
 
     data_override = pyfms.pyDataOverride(cfms)
-    data_override.init(ocn_domain_id=ocn_domain_id)
+    data_override.init(ocn_domain_id=domain.domain_id)
+
     data_override.set_time(year=1, month=1, day=3, hour=0, minute=0, second=0, tick=0)
 
     data = data_override.override_scalar(

--- a/tests/py_diag_manager/test_diag_manager.py
+++ b/tests/py_diag_manager/test_diag_manager.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pyfms import DiagManager, pyFMS, pyFMS_mpp_domains
+import pyfms
 
 
 def test_send_data():
@@ -29,19 +29,18 @@ def test_send_data():
 
     cfms_path = "./cFMS/libcFMS/.libs/libcFMS.so"
 
-    pyfms = pyFMS(cFMS_path=cfms_path, calendar_type=calendar_type)
-    mpp_domains = pyFMS_mpp_domains(cFMS=pyfms.cFMS)
+    pyfms_obj = pyfms.pyFMS(cFMS_path=cfms_path, calendar_type=calendar_type)
+    mpp_domains_obj = pyfms.mpp_domains(cFMS=pyfms_obj.cFMS)
 
     global_indices = [0, (NX - 1), 0, (NY - 1)]
     layout = [1, 1]
     io_layout = [1, 1]
 
-    mpp_domains.define_domains(
-        domain_id=domain_id,
+    domain = mpp_domains_obj.define_domains(
         global_indices=global_indices,
         layout=layout,
     )
-    mpp_domains.define_io_domain(
+    mpp_domains_obj.define_io_domain(
         domain_id=domain_id,
         io_layout=io_layout,
     )
@@ -50,10 +49,8 @@ def test_send_data():
     diag manager init
     """
 
-    diag_manager = DiagManager(clibFMS=pyfms.cFMS)
+    diag_manager = pyfms.DiagManager(clibFMS=pyfms_obj.cFMS)
     diag_manager.init(diag_model_subset=diag_manager.DIAG_ALL)
-
-    mpp_domains.set_current_domain(domain_id=domain_id)
 
     """
     diag axis init x
@@ -65,6 +62,7 @@ def test_send_data():
         axis_data=x,
         units="point_E",
         cart_name="x",
+        domain_id=domain.domain_id,
         long_name="point_E",
         set_name="atm",
     )
@@ -79,6 +77,7 @@ def test_send_data():
         axis_data=y,
         units="point_N",
         cart_name="y",
+        domain_id=domain.domain_id,
         long_name="point_N",
         set_name="atm",
     )
@@ -213,7 +212,7 @@ def test_send_data():
 
     diag_manager.end()
 
-    pyfms.pyfms_end()
+    pyfms_obj.pyfms_end()
 
 
 if __name__ == "__main__":

--- a/tests/py_mpp/test_define_domains.py
+++ b/tests/py_mpp/test_define_domains.py
@@ -1,9 +1,8 @@
 import os
 
-import numpy as np
 import pytest
 
-from pyfms import pyFMS, pyFMS_mpp, pyFMS_mpp_domains
+from pyfms import mpp, mpp_domains, pyFMS
 
 
 @pytest.mark.create
@@ -16,41 +15,24 @@ def test_create_input_nml():
 @pytest.mark.parallel
 def test_define_domains():
 
-    NX = 96
-    NY = 96
-    NX_FINE = 48
-    NY_FINE = 48
-    X_REFINE = 2
-    Y_REFINE = 2
-    COARSE_NPES = 4
-    FINE_NPES = 4
-
     ndomain = 2
     nnest_domain = 2
-    domain_id = 1
-    nest_domain_id = 1
+    domain_id = -99
+    nest_domain_id = -99
 
-    coarse_global_indices = [0, NX - 1, 0, NY - 1]
-    coarse_npes = COARSE_NPES
-    coarse_pelist = np.empty(shape=COARSE_NPES, dtype=np.int32, order="C")
+    nx = 96
+    ny = 96
+    coarse_global_indices = [0, nx - 1, 0, ny - 1]
+    coarse_npes = 4
+    coarse_pelist = list(range(coarse_npes))
     coarse_tile_id = 0
-    coarse_whalo = 2
-    coarse_ehalo = 2
-    coarse_shalo = 2
-    coarse_nhalo = 2
-    coarse_xflags = 3
-    coarse_yflags = 2
-    is_mosaic = False
-    symmetry = False
 
-    fine_global_indices = [0, NX_FINE - 1, 0, NY_FINE - 1]
-    fine_npes = FINE_NPES
-    fine_pelist = np.empty(shape=FINE_NPES, dtype=np.int32, order="C")
+    nx_fine = 48
+    ny_fine = 48
+    fine_global_indices = [0, nx_fine - 1, 0, ny_fine - 1]
+    fine_npes = 4
+    fine_pelist = list(range(fine_npes))
     fine_tile_id = 1
-    fine_whalo = 2
-    fine_ehalo = 2
-    fine_shalo = 2
-    fine_nhalo = 2
 
     cfms_path = "./cFMS/libcFMS/.libs/libcFMS.so"
 
@@ -61,145 +43,108 @@ def test_define_domains():
         ndomain=ndomain,
         nnest_domain=nnest_domain,
     )
-    mpp = pyFMS_mpp(cFMS=pyfms.cFMS)
-    mpp_domains = pyFMS_mpp_domains(cFMS=pyfms.cFMS)
+
+    mpp_obj = mpp(cFMS=pyfms.cFMS)
+    mpp_domains_obj = mpp_domains(cFMS=pyfms.cFMS)
 
     assert isinstance(pyfms, pyFMS)
 
     """get global pelist"""
 
-    npes = mpp.npes()
-    pyfms.set_pelist_npes(npes_in=npes)
-    global_pelist = mpp.get_current_pelist()
+    mpp_obj.set_pelist_npes(npes_in=mpp_obj.npes())
+    global_pelist = mpp_obj.get_current_pelist()
 
     """set coarse domain as tile=0"""
 
-    for i in range(coarse_npes):
-        coarse_pelist[i] = global_pelist[i]
-    name_coarse = "test coarse pelist"
-    pyfms.set_pelist_npes(npes_in=coarse_npes)
-    mpp.declare_pelist(pelist=coarse_pelist, name=name_coarse)
+    coarse_pelist = global_pelist[:coarse_npes]
+    mpp_obj.set_pelist_npes(npes_in=coarse_npes)
+    mpp_obj.declare_pelist(pelist=coarse_pelist, name="test coarse pelist")
 
-    if mpp.pe() in coarse_pelist:
-        pyfms.set_pelist_npes(coarse_npes)
-        mpp.set_current_pelist(coarse_pelist)
-        name = "test coarse domain"
-        maskmap = np.full(shape=(2, 4), fill_value=True, dtype=np.bool_)
+    if mpp_obj.pe() in coarse_pelist:
+        mpp_obj.set_pelist_npes(coarse_npes)
+        mpp_obj.set_current_pelist(coarse_pelist)
 
-        xextent = np.zeros(shape=2, dtype=np.int32, order="C")
-        yextent = np.zeros(shape=2, dtype=np.int32, order="C")
-        is_mosaic = False
-
-        ndivs = coarse_npes
-
-        layout = mpp_domains.define_layout(
+        layout = mpp_domains_obj.define_layout(
             global_indices=coarse_global_indices,
-            ndivs=ndivs,
+            ndivs=coarse_npes,
         )
 
-        mpp_domains.define_domains(
+        domain = mpp_domains_obj.define_domains(
             global_indices=coarse_global_indices,
             layout=layout,
-            domain_id=domain_id,
             pelist=coarse_pelist,
-            xflags=coarse_xflags,
-            yflags=coarse_yflags,
-            xextent=xextent,
-            yextent=yextent,
-            maskmap=maskmap,
-            name=name,
-            symmetry=symmetry,
-            whalo=coarse_whalo,
-            ehalo=coarse_ehalo,
-            shalo=coarse_shalo,
-            nhalo=coarse_nhalo,
-            is_mosaic=is_mosaic,
+            xflags=mpp_domains_obj.WEST,
+            yflags=mpp_domains_obj.SOUTH,
+            xextent=[nx / 2] * 4,
+            yextent=[ny / 2] * 4,
+            maskmap=[[True, True], [True, True]],
+            name="test coarse domain",
+            symmetry=False,
+            whalo=2,
+            ehalo=2,
+            shalo=2,
+            nhalo=2,
+            is_mosaic=False,
             tile_id=coarse_tile_id,
         )
-
-    mpp.set_current_pelist()
+        assert domain.domain_id == 0
+    mpp_obj.set_current_pelist()
 
     """set fine domain as tile=1"""
 
-    name_fine = "test fine pelist"
-    for i in range(fine_npes):
-        fine_pelist[i] = global_pelist[COARSE_NPES + i]
-    pyfms.set_pelist_npes(fine_npes)
-    mpp.declare_pelist(pelist=fine_pelist, name=name_fine)
+    fine_pelist = global_pelist[coarse_npes : coarse_npes + fine_npes]
+    mpp_obj.set_pelist_npes(fine_npes)
+    mpp_obj.declare_pelist(pelist=fine_pelist, name="test fine pelist")
 
-    if mpp.pe() in fine_pelist:
-        pyfms.set_pelist_npes(fine_npes)
-        mpp.set_current_pelist(pelist=fine_pelist)
+    if mpp_obj.pe() in fine_pelist:
+        mpp_obj.set_pelist_npes(fine_npes)
+        mpp_obj.set_current_pelist(pelist=fine_pelist)
 
-        name = "test fine domain"
-        ndivs = FINE_NPES
-
-        layout = mpp_domains.define_layout(
+        layout = mpp_domains_obj.define_layout(
             global_indices=fine_global_indices,
-            ndivs=ndivs,
+            ndivs=fine_npes,
         )
 
-        mpp_domains.define_domains(
+        domain = mpp_domains_obj.define_domains(
             global_indices=fine_global_indices,
             layout=layout,
-            domain_id=domain_id,
             pelist=fine_pelist,
-            name=name,
-            symmetry=symmetry,
-            whalo=fine_whalo,
-            ehalo=fine_ehalo,
-            shalo=fine_shalo,
-            nhalo=fine_nhalo,
-            is_mosaic=is_mosaic,
+            name="test fine domain",
+            symmetry=False,
+            whalo=2,
+            ehalo=2,
+            shalo=2,
+            nhalo=2,
+            is_mosaic=False,
             tile_id=fine_tile_id,
         )
+        assert domain.domain_id == 0
+    assert mpp_domains_obj.domain_is_initialized(domain.domain_id)
 
-    mpp.set_current_pelist()
-
-    assert mpp_domains.domain_is_initialized(domain_id)
+    mpp_obj.set_current_pelist()
 
     """set nest domain"""
 
-    name = "test nest domain"
-    num_nest = 1
-    ntiles = 2
-    nest_level = np.array([1], dtype=np.int32, order="C")
-    istart_coarse = np.array([24], dtype=np.int32, order="C")
-    icount_coarse = np.array([24], dtype=np.int32, order="C")
-    jstart_coarse = np.array([24], dtype=np.int32, order="C")
-    jcount_coarse = np.array([24], dtype=np.int32, order="C")
-    npes_nest_tile = np.array([COARSE_NPES, FINE_NPES], dtype=np.int32, order="C")
-    x_refine = np.array([X_REFINE], dtype=np.int32, order="C")
-    y_refine = np.array([Y_REFINE], dtype=np.int32, order="C")
-    tile_fine = np.array([fine_tile_id], dtype=np.int32, order="C")
-    tile_coarse = np.array([coarse_tile_id], dtype=np.int32, order="C")
-    nest_domain_id = nest_domain_id
-    domain_id = domain_id
-
-    mpp_domains.define_nest_domains(
-        num_nest=num_nest,
-        ntiles=ntiles,
-        nest_level=nest_level,
-        tile_fine=tile_fine,
-        tile_coarse=tile_coarse,
-        istart_coarse=istart_coarse,
-        icount_coarse=icount_coarse,
-        jstart_coarse=jstart_coarse,
-        jcount_coarse=jcount_coarse,
-        npes_nest_tile=npes_nest_tile,
-        x_refine=x_refine,
-        y_refine=y_refine,
-        nest_domain_id=nest_domain_id,
-        domain_id=domain_id,
-        extra_halo=None,
-        name=name,
+    nest_domain = mpp_domains_obj.define_nest_domains(
+        num_nest=1,
+        ntiles=2,
+        nest_level=[1],
+        tile_fine=[fine_tile_id],
+        tile_coarse=[coarse_tile_id],
+        istart_coarse=[24],
+        icount_coarse=[24],
+        jstart_coarse=[24],
+        jcount_coarse=[24],
+        npes_nest_tile=[coarse_npes, fine_npes],
+        x_refine=[2],
+        y_refine=[2],
+        domain_id=domain.domain_id,
+        name="test nest domain",
     )
 
-    mpp.set_current_pelist()
+    mpp_obj.set_current_pelist()
 
     pyfms.pyfms_end()
-
-    # mpp.pyfms_error(errortype=1)
 
 
 @pytest.mark.remove

--- a/tests/py_mpp/test_update_domains.py
+++ b/tests/py_mpp/test_update_domains.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 
-from pyfms import pyDomain, pyFMS, pyFMS_mpp, pyFMS_mpp_domains
+from pyfms import mpp, mpp_domains, pyFMS
 
 
 @pytest.mark.create
@@ -25,95 +25,98 @@ def test_update_domains():
     shalo = 2
     domain_id = 0
 
-    pyfms = pyFMS(cFMS_path="./cFMS/libcFMS/.libs/libcFMS.so")
-    mpp = pyFMS_mpp(cFMS=pyfms.cFMS)
-    mpp_domains = pyFMS_mpp_domains(cFMS=pyfms.cFMS)
+    pyfms_obj = pyFMS(cFMS_path="./cFMS/libcFMS/.libs/libcFMS.so")
+    mpp_obj = mpp(cFMS=pyfms_obj.cFMS)
+    mpp_domains_obj = mpp_domains(cFMS=pyfms_obj.cFMS)
 
     global_indices = [0, (nx - 1), 0, (ny - 1)]
-    cyclic_global_domain = 2
 
-    layout = mpp_domains.define_layout(global_indices=global_indices, ndivs=npes)
+    layout = mpp_domains_obj.define_layout(global_indices=global_indices, ndivs=npes)
 
-    domain = pyDomain(
+    domain = mpp_domains_obj.define_domains(
         global_indices=global_indices,
         layout=layout,
-        mpp_domains_obj=mpp_domains,
-        domain_id=domain_id,
         whalo=whalo,
         ehalo=ehalo,
         shalo=shalo,
         nhalo=nhalo,
-        xflags=cyclic_global_domain,
-        yflags=cyclic_global_domain,
+        xflags=mpp_domains_obj.CYCLIC_GLOBAL_DOMAIN,
+        yflags=mpp_domains_obj.CYCLIC_GLOBAL_DOMAIN,
     )
 
     answers = np.array(
         [
             [
-                [88, 98, 28, 38, 48, 58, 68, 78],
-                [89, 99, 29, 39, 49, 59, 69, 79],
-                [82, 92, 22, 32, 42, 52, 62, 72],
-                [83, 93, 23, 33, 43, 53, 63, 73],
-                [84, 94, 24, 34, 44, 54, 64, 74],
-                [85, 95, 25, 35, 45, 55, 65, 75],
-                [86, 96, 26, 36, 46, 56, 66, 76],
-                [87, 97, 27, 37, 47, 57, 67, 77],
+                [66, 76, 6, 16, 26, 36, 46, 56],
+                [67, 77, 7, 17, 27, 37, 47, 57],
+                [60, 70, 0, 10, 20, 30, 40, 50],
+                [61, 71, 1, 11, 21, 31, 41, 51],
+                [62, 72, 2, 12, 22, 32, 42, 52],
+                [63, 73, 3, 13, 23, 33, 43, 53],
+                [64, 74, 4, 14, 24, 34, 44, 54],
+                [65, 75, 5, 15, 25, 35, 45, 55],
             ],
             [
-                [84, 94, 24, 34, 44, 54, 64, 74],
-                [85, 95, 25, 35, 45, 55, 65, 75],
-                [86, 96, 26, 36, 46, 56, 66, 76],
-                [87, 97, 27, 37, 47, 57, 67, 77],
-                [88, 98, 28, 38, 48, 58, 68, 78],
-                [89, 99, 29, 39, 49, 59, 69, 79],
-                [82, 92, 22, 32, 42, 52, 62, 72],
-                [83, 93, 23, 33, 43, 53, 63, 73],
+                [62, 72, 2, 12, 22, 32, 42, 52],
+                [63, 73, 3, 13, 23, 33, 43, 53],
+                [64, 74, 4, 14, 24, 34, 44, 54],
+                [65, 75, 5, 15, 25, 35, 45, 55],
+                [66, 76, 6, 16, 26, 36, 46, 56],
+                [67, 77, 7, 17, 27, 37, 47, 57],
+                [60, 70, 0, 10, 20, 30, 40, 50],
+                [61, 71, 1, 11, 21, 31, 41, 51],
             ],
             [
-                [48, 58, 68, 78, 88, 98, 28, 38],
-                [49, 59, 69, 79, 89, 99, 29, 39],
-                [42, 52, 62, 72, 82, 92, 22, 32],
-                [43, 53, 63, 73, 83, 93, 23, 33],
-                [44, 54, 64, 74, 84, 94, 24, 34],
-                [45, 55, 65, 75, 85, 95, 25, 35],
-                [46, 56, 66, 76, 86, 96, 26, 36],
-                [47, 57, 67, 77, 87, 97, 27, 37],
+                [26, 36, 46, 56, 66, 76, 6, 16],
+                [27, 37, 47, 57, 67, 77, 7, 17],
+                [20, 30, 40, 50, 60, 70, 0, 10],
+                [21, 31, 41, 51, 61, 71, 1, 11],
+                [22, 32, 42, 52, 62, 72, 2, 12],
+                [23, 33, 43, 53, 63, 73, 3, 13],
+                [24, 34, 44, 54, 64, 74, 4, 14],
+                [25, 35, 45, 55, 65, 75, 5, 15],
             ],
             [
-                [44, 54, 64, 74, 84, 94, 24, 34],
-                [45, 55, 65, 75, 85, 95, 25, 35],
-                [46, 56, 66, 76, 86, 96, 26, 36],
-                [47, 57, 67, 77, 87, 97, 27, 37],
-                [48, 58, 68, 78, 88, 98, 28, 38],
-                [49, 59, 69, 79, 89, 99, 29, 39],
-                [42, 52, 62, 72, 82, 92, 22, 32],
-                [43, 53, 63, 73, 83, 93, 23, 33],
+                [22, 32, 42, 52, 62, 72, 2, 12],
+                [23, 33, 43, 53, 63, 73, 3, 13],
+                [24, 34, 44, 54, 64, 74, 4, 14],
+                [25, 35, 45, 55, 65, 75, 5, 15],
+                [26, 36, 46, 56, 66, 76, 6, 16],
+                [27, 37, 47, 57, 67, 77, 7, 17],
+                [20, 30, 40, 50, 60, 70, 0, 10],
+                [21, 31, 41, 51, 61, 71, 1, 11],
             ],
         ],
         dtype=np.float32,
     )
 
-    xdatasize = whalo + nx + ehalo
-    ydatasize = shalo + ny + nhalo
+    compute = mpp_domains_obj.get_compute_domain(
+        domain_id=domain.domain_id, whalo=whalo, shalo=shalo
+    )
+    data = mpp_domains_obj.get_data_domain(
+        domain_id=domain.domain_id, whalo=whalo, shalo=shalo
+    )
 
-    isc = domain.compute_domain.xbegin.value
-    jsc = domain.compute_domain.ybegin.value
-    xsize_c = domain.compute_domain.xsize.value
-    ysize_c = domain.compute_domain.ysize.value
-    xsize_d = domain.data_domain.xsize.value
-    ysize_d = domain.data_domain.ysize.value
+    isc = compute["xbegin"]
+    jsc = compute["ybegin"]
+    xsize_c = compute["xsize"]
+    ysize_c = compute["ysize"]
+    xsize_d = data["xsize"]
+    ysize_d = data["ysize"]
 
-    global_data = np.zeros(shape=(xdatasize, ydatasize), dtype=np.float32)
+    global_data = np.zeros(
+        shape=(nx + ehalo + whalo, ny + ehalo + whalo), dtype=np.float32
+    )
     for ix in range(nx):
         for iy in range(ny):
-            global_data[whalo + ix][shalo + iy] = (iy + shalo) * 10 + (ix + whalo)
+            global_data[whalo + ix][shalo + iy] = iy * 10 + ix
 
     idata = np.zeros(shape=(xsize_d, ysize_d), dtype=np.float32)
-    for ix in range(xsize_c):
-        for iy in range(ysize_c):
-            idata[ix + whalo][iy + whalo] = global_data[isc + ix][jsc + iy]
+    for i in range(xsize_c):
+        for j in range(ysize_c):
+            idata[whalo + i][shalo + j] = global_data[isc + i][jsc + j]
 
-    mpp_domains.update_domains(
+    mpp_domains_obj.update_domains(
         field=idata,
         domain_id=domain_id,
         whalo=whalo,
@@ -122,9 +125,9 @@ def test_update_domains():
         nhalo=nhalo,
     )
 
-    assert np.array_equal(idata, answers[mpp.pe()])
+    assert np.array_equal(idata, answers[mpp_obj.pe()])
 
-    pyfms.pyfms_end()
+    pyfms_obj.pyfms_end()
 
 
 @pytest.mark.remove


### PR DESCRIPTION
In this PR,

mpp functions have been modified to accept domain_id returned from cFMS. In addition, this PR brings in minor cleanups.

This PR is the correctly based version of  PR #3 