### PR TITLE
adds mpp_gather_pelist in py_mpp

### DIFF
--- a/compile_c_libs.sh
+++ b/compile_c_libs.sh
@@ -4,10 +4,10 @@ set -ex
 #set -o posix
 
 #yaml includes
-YAML_FLAGS+=""
+YAML_FLAGS+="-I/opt/libyaml/0.2.5/GNU/14.2.0/include"
 
 #yaml libraries
-YAML_LDFLAGS+=""
+YAML_LDFLAGS+="-L/opt/libyaml/0.2.5/GNU/14.2.0/lib"
 
 #fortran netcdf includes
 NF_FLAGS+=$(nf-config --fflags)
@@ -23,15 +23,15 @@ FC=mpif90
 CC=mpicc
 
 #fms fortran, c, library compiler flags
-FMS_FCFLAGS+="$NF_FLAGS -fPIC"
-FMS_CFLAGS+="$NC_FLAGS $YAML_FLAGS -fPIC"
+FMS_FCFLAGS+="$NF_FLAGS -fPIC -fmax-errors=10"
+FMS_CFLAGS+="$NC_FLAGS $YAML_FLAGS -fPIC -fmax-errors=10"
 FMS_LDFLAGS+="$NC_LDFLAGS $YAML_LDFLAGS"
 
 #cfms fortran, c, library compiler flags
 #cfms does not need the netcdf flags.
 #these will be removed once cfms configure.ac is updated
-cFMS_FCFLAGS+="-fPIC $NF_FLAGS"
-cFMS_CFLAGS+="-fPIC $NC_FLAGS"
+cFMS_FCFLAGS+="-fPIC $NF_FLAGS -fmax-errors=10"
+cFMS_CFLAGS+="-fPIC $NC_FLAGS -fmax-errors=10"
 cFMS_LDFLAGS+=""
 
 curr_dir=$PWD

--- a/pyfms/py_mpp/_mpp_functions.py
+++ b/pyfms/py_mpp/_mpp_functions.py
@@ -5,7 +5,7 @@ import numpy as np
 from pyfms.utils.ctypes_utils import NDPOINTERi32
 
 
-npptr = np.ctypeslib.ndpointer
+ndpointer = np.ctypeslib.ndpointer
 C = "C_CONTIGUOUS"
 
 
@@ -18,14 +18,11 @@ def define(lib):
     during package initialization
     """
 
-    # cFMS_set_pelist_npes
-    lib.cFMS_set_pelist_npes.restype = None
-    lib.cFMS_set_pelist_npes.argtypes = [POINTER(c_int)]  # npes
-
     # cFMS_declare_pelist
     lib.cFMS_declare_pelist.restype = None
     lib.cFMS_declare_pelist.argtypes = [
-        npptr(dtype=np.int32, ndim=(1), flags=C),  # pelist
+        POINTER(c_int),  # npes
+        ndpointer(dtype=np.int32, ndim=(1), flags=C),  # pelist
         c_char_p,  # name
     ]
 
@@ -33,10 +30,35 @@ def define(lib):
     lib.cFMS_error.restype = None
     lib.cFMS_error.argtypes = [POINTER(c_int), c_char_p]  # errortype  # errormsg
 
+    # cFMS_gather_pelist_2ds
+    gatherdict = {np.int32: lib.cFMS_gather_pelist_2d_cint,
+                np.float64: lib.cFMS_gather_pelist_2d_cdouble,
+                np.float32: lib.cFMS_gather_pelist_2d_cfloat
+    }
+    for nptype, cFMS_gather_pelist_2d in gatherdict.items():
+        cFMS_gather_pelist_2d.restype = None
+        cFMS_gather_pelist_2d.argtypes = [
+            POINTER(c_int), # is
+            POINTER(c_int), # ie
+            POINTER(c_int), # js
+            POINTER(c_int), # je
+            POINTER(c_int), # npes
+            ndpointer(dtype=np.int32, ndim=(1), flags=C), #pelist
+            ndpointer(dtype=nptype, ndim=(2), flags=C), #array_seg
+            ndpointer(dtype=np.int32, shape=(2,), flags=C), #gather_data_c_shape
+            ndpointer(dtype=nptype, ndim=(2), flags=C), #gather_data
+            POINTER(c_bool), #is root_pe
+            POINTER(c_int), # ishift
+            POINTER(c_int), # jshift
+            POINTER(c_bool), #convert_cf_order
+        ]
+        
+
     # cFMS_get_current_pelist
     lib.cFMS_get_current_pelist.restype = None
     lib.cFMS_get_current_pelist.argtypes = [
-        npptr(dtype=np.int32, ndim=(1), flags=C),  # pelist
+        POINTER(c_int),  # npes
+        ndpointer(dtype=np.int32, ndim=(1), flags=C),  # pelist
         c_char_p,  # name
         POINTER(c_int),  # commID
     ]
@@ -52,6 +74,7 @@ def define(lib):
     # cFMS_set_current_pelist
     lib.cFMS_set_current_pelist.restype = None
     lib.cFMS_set_current_pelist.argtypes = [
-        NDPOINTERi32(npptr(dtype=np.int32, ndim=(1), flags=C)),  # pelist
+        POINTER(c_int),  # npes
+        NDPOINTERi32(ndpointer(dtype=np.int32, ndim=(1), flags=C)),  # pelist
         POINTER(c_bool),  # no_sync
     ]

--- a/pyfms/py_mpp/_mpp_functions.py
+++ b/pyfms/py_mpp/_mpp_functions.py
@@ -71,6 +71,10 @@ def define(lib):
     lib.cFMS_pe.restype = c_int
     lib.cFMS_pe.argtypes = None
 
+    # cFMS_root_pe
+    lib.cFMS_root_pe.restype = c_int
+    lib.cFMS_root_pe.argtypes = None
+    
     # cFMS_set_current_pelist
     lib.cFMS_set_current_pelist.restype = None
     lib.cFMS_set_current_pelist.argtypes = [

--- a/pyfms/py_mpp/domain.py
+++ b/pyfms/py_mpp/domain.py
@@ -10,28 +10,32 @@ class Domain:
     """
 
     def __init__(
-        self,
-        domain_id: int = None,
-        isc: int = None,
-        jsc: int = None,
-        iec: int = None,
-        jec: int = None,
-        isd: int = None,
-        jsd: int = None,
-        ied: int = None,
-        jed: int = None,
-        xsize_c: int = None,
-        ysize_c: int = None,
-        xmax_size_c: int = None,
-        ymax_size_c: int = None,
-        x_is_global_c: int = None,
-        y_is_global_c: int = None,
-        xsize_d: int = None,
-        ysize_d: int = None,
-        xmax_size_d: int = None,
-        ymax_size_d: int = None,
-        x_is_global_d: bool = None,
-        y_is_global_d: bool = None,
+            self,
+            domain_id: int = None,
+            isc: int = None,
+            jsc: int = None,
+            iec: int = None,
+            jec: int = None,
+            isd: int = None,
+            jsd: int = None,
+            ied: int = None,
+            jed: int = None,
+            isg: int = None,
+            ieg: int = None,
+            jsg: int = None,
+            jeg: int = None,
+            xsize_c: int = None,
+            ysize_c: int = None,
+            xmax_size_c: int = None,
+            ymax_size_c: int = None,
+            x_is_global_c: int = None,
+            y_is_global_c: int = None,
+            xsize_d: int = None,
+            ysize_d: int = None,
+            xmax_size_d: int = None,
+            ymax_size_d: int = None,
+            x_is_global_d: bool = None,
+            y_is_global_d: bool = None,
     ):
         self.domain_id = domain_id  # domain_id
         self.isc = isc  # xbegin in compute domain
@@ -42,6 +46,10 @@ class Domain:
         self.jsd = jsd  # ybegin in data_domain
         self.ied = ied  # xend in data_domain
         self.jed = jed  # yend in data_domain
+        self.isg = isg  # xbegin in global domain
+        self.ieg = ieg  # xend in global domain
+        self.jsg = jsg  # ybegin in global domain
+        self.jeg = jeg  # yend in global domain
         self.xsize_c = xsize_c  # xsize in compute domain
         self.ysize_c = ysize_c  # ysize in compute domain
         self.xmax_size_c = xmax_size_c  # xmax_size in compute domain
@@ -54,6 +62,7 @@ class Domain:
         self.ymax_size_d = ymax_size_d  # ymax_size in data domain
         self.x_is_global_d = x_is_global_d  # x_is_global in data domain
         self.y_is_global_d = y_is_global_d  # y_is_global in data domain
+
 
     def update(self, domain_dict: dict):
         for key in domain_dict:

--- a/pyfms/py_mpp/mpp.py
+++ b/pyfms/py_mpp/mpp.py
@@ -51,7 +51,7 @@ def gather(domain: dict, send_array: npt.NDArray, pelist: list = None, ishift: i
     nx = domain.ieg-domain.isg+1 if is_root_pe else 1    
     ny = domain.jeg-domain.jsg+1 if is_root_pe else 1
     receive_shape = (nx, ny) if convert_cf_order else (ny, nx)
-    
+
     arglist = []
     set_c_int(domain.isc, arglist)
     set_c_int(domain.iec, arglist)

--- a/pyfms/py_mpp/mpp_domains.py
+++ b/pyfms/py_mpp/mpp_domains.py
@@ -254,6 +254,11 @@ def define_domains(
     for key in data:
         setattr(domain, key, data[key])
 
+    domain.isg = global_indices[0]
+    domain.ieg = global_indices[1]
+    domain.jsg = global_indices[2]
+    domain.jeg = global_indices[3]
+        
     return domain
 
 

--- a/pyfms/utils/ctypes_utils.py
+++ b/pyfms/utils/ctypes_utils.py
@@ -82,7 +82,10 @@ def set_array(arg: npt.ArrayLike | None, arglist: list) -> npt.ArrayLike | None:
     if arg is None:
         return setNone(arglist)
 
-    arglist.append(arg)
+    if not arg.flags['FORC']:
+        arglist.append(np.ascontiguousarray(arg))
+    else:
+        arglist.append(arg)
     return arg
 
 

--- a/tests/py_mpp/test_gather.py
+++ b/tests/py_mpp/test_gather.py
@@ -5,32 +5,32 @@ import pyfms
 
 def test_gather():
 
-    nx, ny = 32, 64
-    global_indices = [0, nx-1, 0, ny-1]
-    
     pyfms.fms.init(ndomain=2)
-
-    #define domain
-    layout = pyfms.mpp_domains.define_layout(global_indices, pyfms.mpp.npes())
-    domain = pyfms.mpp_domains.define_domains(global_indices, layout)
-
-    print('here', pyfms.mpp.npes(), layout, global_indices)
-    pyfms.fms.end()
-    exit()
     
-    #data to send
-    pe = pyfms.mpp.pe()
-    send = np.array([[i*100 + j for j in range(domain.jsc, domain.jec)] for i in range(domain.isc, domain.iec)], dtype=np.float64)
+    for convert in [True, False]:
+    
+        nx, ny = 12, 24
+        global_indices = [0, nx-1, 0, ny-1]
 
-    pelist = pyfms.mpp.get_current_pelist(pyfms.mpp.npes())
-    gathered = pyfms.mpp.gather(domain, send, pelist=pelist)
+        #define domain
+        layout = pyfms.mpp_domains.define_layout(global_indices, pyfms.mpp.npes())
+        domain = pyfms.mpp_domains.define_domains(global_indices, layout)
+
+        #data to send
+        global_data = np.array([[i*100+j for j in range(ny)] for i in range(nx)], dtype=np.float64)
+        send = global_data[domain.isc:domain.iec+1, domain.jsc:domain.jec+1]
+
+        if not convert:
+            global_data = global_data.T
+            send = send.T
+            
+        pelist = pyfms.mpp.get_current_pelist(pyfms.mpp.npes())
+        gathered = pyfms.mpp.gather(domain, send, pelist=pelist, convert_cf_order=convert)
+    
+        if pyfms.mpp.pe() == pyfms.mpp.root_pe():
+            assert np.all(global_data == gathered)
+        else:
+            assert gathered is None
 
     pyfms.fms.end()
-
-    answers = np.array([[i*100+j for j in range(ny)] for i in range(nx)], dtype=np.float64)
-
-    if pe == pyfms.mpp.root_pe():
-        assert np.all(answers == gathered)
-    else:
-        assert gathered is None
     

--- a/tests/py_mpp/test_gather.py
+++ b/tests/py_mpp/test_gather.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+import pyfms
+
+
+def test_gather():
+
+    nx, ny = 32, 64
+    global_indices = [0, nx-1, 0, ny-1]
+    
+    pyfms.fms.init(ndomain=2)
+
+    #define domain
+    layout = pyfms.mpp_domains.define_layout(global_indices, pyfms.mpp.npes())
+    domain = pyfms.mpp_domains.define_domains(global_indices, layout)
+
+    print('here', pyfms.mpp.npes(), layout, global_indices)
+    pyfms.fms.end()
+    exit()
+    
+    #data to send
+    pe = pyfms.mpp.pe()
+    send = np.array([[i*100 + j for j in range(domain.jsc, domain.jec)] for i in range(domain.isc, domain.iec)], dtype=np.float64)
+
+    pelist = pyfms.mpp.get_current_pelist(pyfms.mpp.npes())
+    gathered = pyfms.mpp.gather(domain, send, pelist=pelist)
+
+    pyfms.fms.end()
+
+    answers = np.array([[i*100+j for j in range(ny)] for i in range(nx)], dtype=np.float64)
+
+    if pe == pyfms.mpp.root_pe():
+        assert np.all(answers == gathered)
+    else:
+        assert gathered is None
+    


### PR DESCRIPTION
**Description**
This PR,
1.  removes function `set_pelist_npes`  and modifies the necessary functions to send `npes` as a function argument to cFMS.  These changes are required in order to interface the newly modified cFMS.
2.  adds `pyfms.mpp.gather` function for 2d np.float32 and np.float64 data
3.  adds 'pyfms.mpp.root_pe`
4.  adds global domain attributes to the class Domain.
5.  makes cosmetic corrections 