### PR TITLE
update handling of time values in diag manager

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -9,6 +9,8 @@ concurrency:
 jobs:
   pyfms_unit_tests:
     runs-on: ubuntu-latest
+    env:
+      LD_LIBRARY_PATH:
     steps:
         - name: Checkout out hash that triggered CI
           uses: actions/checkout@v4
@@ -25,4 +27,6 @@ jobs:
           run: |
             pip install .[test]
         - name: run tests
-          run: cd tests && ./run_tests.sh -o
+          run: |
+            cd tests
+            ./run_tests.sh -o

--- a/pyfms/py_diag_manager/_functions.py
+++ b/pyfms/py_diag_manager/_functions.py
@@ -20,7 +20,9 @@ def define(lib):
 
     # cFMS_diag_end
     lib.cFMS_diag_end.restype = None
-    lib.cFMS_diag_end.argtypes = None
+    lib.cFMS_diag_end.argtypes = [
+        NDPOINTERi32(npptr(np.int32, shape=(7), flags=C)),
+    ]
 
     # cFMS_diag_init
     lib.cFMS_diag_init.restype = None
@@ -30,42 +32,12 @@ def define(lib):
         c_char_p,  # err_msg
     ]
 
-    lib.c_diag_manager_is_initialized.restype = c_bool
-    lib.c_diag_manager_is_initialized.argtypes = None
-
     # cFMS_send_complete
     lib.cFMS_diag_send_complete.restype = None
     lib.cFMS_diag_send_complete.argtypes = [
-        POINTER(c_int),  # diag_field_id
+        NDPOINTERi32(npptr(np.int32, shape=(7), flags=C)),  # time_init
         c_char_p,  # err_msg
     ]
-
-    # cFMS_diag_set_field_init_time
-    lib.cFMS_diag_set_field_init_time.restype = None
-    lib.cFMS_diag_set_field_init_time.argtypes = [
-        POINTER(c_int),  # year
-        POINTER(c_int),  # month
-        POINTER(c_int),  # day
-        POINTER(c_int),  # hour
-        POINTER(c_int),  # minute
-        POINTER(c_int),  # second
-        POINTER(c_int),  # tick
-        c_char_p,  # err_msg
-    ]
-
-    # cFMS_set_field_timestep
-    lib.cFMS_diag_set_field_timestep.restype = None
-    lib.cFMS_diag_set_field_timestep.argtypes = [
-        POINTER(c_int),  # diag_field_id
-        POINTER(c_int),  # dseconds
-        POINTER(c_int),  # ddays
-        POINTER(c_int),  # dticks
-        c_char_p,  # err_msg
-    ]
-
-    # cFMS_diag_advance_field_time
-    lib.cFMS_diag_advance_field_time.restype = None
-    lib.cFMS_diag_advance_field_time.argtypes = [POINTER(c_int)]
 
     # cFMS_diag_set_time_end
     lib.cFMS_diag_set_time_end.restype = None
@@ -76,7 +48,7 @@ def define(lib):
         POINTER(c_int),  # hour
         POINTER(c_int),  # minute
         POINTER(c_int),  # second
-        POINTER(c_int),  # tick
+        POINTER(c_int),  # ticks
         c_char_p,  # err_msg
     ]
 
@@ -119,6 +91,7 @@ def define(lib):
             c_char_p,  # field_name
             c_char_p,  # long_name
             c_char_p,  # units
+            POINTER(c_int), # time
             c_char_p,  # standard_name
             POINTER(ictype),  # missing_value
             NDPOINTER(npptr(dtype, shape=(2), flags=C)),  # range
@@ -145,6 +118,7 @@ def define(lib):
             npptr(np.int32, shape=(5), flags=C),  # axes
             c_char_p,  # long_name
             c_char_p,  # units
+            npptr(np.int32, shape=(7), flags=C),  # time
             POINTER(ictype),  # missing_value
             NDPOINTER(npptr(dtype, shape=(2), flags=C)),  # range
             POINTER(c_bool),  # mask_variant
@@ -173,4 +147,5 @@ def define(lib):
                 npptr(dtype, ndim=ndim, flags=C),  # field
                 c_char_p,  # err_msg
                 POINTER(c_bool),  # convert_cf_order
+                npptr(np.int32, shape=(7), flags=C), # time
             ]

--- a/pyfms/py_diag_manager/_functions.py
+++ b/pyfms/py_diag_manager/_functions.py
@@ -91,7 +91,7 @@ def define(lib):
             c_char_p,  # field_name
             c_char_p,  # long_name
             c_char_p,  # units
-            POINTER(c_int), # time
+            POINTER(c_int),  # time
             c_char_p,  # standard_name
             POINTER(ictype),  # missing_value
             NDPOINTER(npptr(dtype, shape=(2), flags=C)),  # range
@@ -147,5 +147,5 @@ def define(lib):
                 npptr(dtype, ndim=ndim, flags=C),  # field
                 c_char_p,  # err_msg
                 POINTER(c_bool),  # convert_cf_order
-                npptr(np.int32, shape=(7), flags=C), # time
+                npptr(np.int32, shape=(7), flags=C),  # time
             ]

--- a/pyfms/py_diag_manager/_functions.py
+++ b/pyfms/py_diag_manager/_functions.py
@@ -21,7 +21,7 @@ def define(lib):
     # cFMS_diag_end
     lib.cFMS_diag_end.restype = None
     lib.cFMS_diag_end.argtypes = [
-        NDPOINTERi32(npptr(np.int32, shape=(7), flags=C)),
+        npptr(np.int32, shape=(7), flags=C),
     ]
 
     # cFMS_diag_init

--- a/pyfms/py_diag_manager/diag_manager.py
+++ b/pyfms/py_diag_manager/diag_manager.py
@@ -3,6 +3,8 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
+from datetime import datetime, timedelta
+
 from pyfms.py_diag_manager import _functions
 from pyfms.utils.ctypes_utils import (
     check_str,
@@ -23,8 +25,6 @@ DIAG_OTHER = None
 
 _libpath = None
 _lib = None
-
-_c_diag_manager_is_initialized = None
 
 _cFMS_diag_end = None
 _cFMS_diag_init = None
@@ -55,21 +55,29 @@ _cFMS_register_diag_field_arrays = {}
 _cFMS_register_diag_field_scalars = {}
 _cFMS_diag_send_datas = {}
 
-
-def end():
-
+# TODO: ideally, end_time would be optional here since it can be set prior to the end of a run via set_time_end.
+# FMS usage typically sets the end time with diag_manager_end instead, so leaving this as is for now
+def end(end_time: datetime):
     """
-    This function must be called in order to flush out
-    the diagnostic buffers and properly close
-    the diagnostic files
+    Called at end of a run to write and close any diagnostic files.
     """
+    arglist = []
 
-    _cFMS_diag_end()
+    int_time = []
+    int_time.append(end_time.year)
+    int_time.append(end_time.month)
+    int_time.append(end_time.day)
+    int_time.append(end_time.hour)
+    int_time.append(end_time.minute)
+    int_time.append(end_time.second)
+    int_time.append(0) # ticks
+    set_list(int_time, np.int32, arglist)
+    _cFMS_diag_end(*arglist)
 
 
 def init(
     diag_model_subset: int = None,
-    time_init: list = None,
+    time_init: datetime = None,
 ) -> str:
 
     """
@@ -89,7 +97,18 @@ def init(
 
     arglist = []
     set_c_int(diag_model_subset, arglist)
-    set_list(time_init, np.int32, arglist)
+    if time_init is not None:
+        int_time = []
+        int_time.append(time_init.year)
+        int_time.append(time_init.month)
+        int_time.append(time_init.day)
+        int_time.append(time_init.hour)
+        int_time.append(time_init.minute)
+        int_time.append(time_init.second)
+        int_time.append(0) # ticks
+    else:
+        int_time = None
+    set_list(int_time, np.int32, arglist)
     err_msg = set_c_str(" ", arglist)
 
     _cFMS_diag_init(*arglist)
@@ -97,25 +116,28 @@ def init(
     return err_msg.value.decode("utf-8")
 
 
-def module_is_initialized():
+def send_complete(timestep: timedelta, ticks: int = 0) -> str:
 
     """
-    returns module_is_initialized from c_diag_manager_mod
+    Finishes diag manager operations for this timestep; performing any reductions and writing to the file(s).
+    This function must be called after all data for a given timestep has been sent via send_data.
     """
-
-    return _c_diag_manager_is_initialized()
-
-
-def send_complete(diag_field_id: int) -> str:
-
-    """
-    Completes send_data
-    This function must be called after the final send data
-    call for the given time
-    """
-
     arglist = []
-    set_c_int(diag_field_id, arglist)
+
+    dtime = datetime.min + timestep
+    int_time = []
+    # this may need adjustments due to slight differences in datetime/timedelta and fms Time_type
+    int_time.append(dtime.year)
+    int_time.append(dtime.month)
+    int_time.append(dtime.day)
+    int_time.append(dtime.hour)
+    int_time.append(dtime.minute)
+    int_time.append(dtime.second)
+    int_time.append(ticks)
+
+    print(f"send complete timestep:{timestep}\ndtime:{dtime}")
+
+    set_list(int_time, np.int32, arglist)
     err_msg = set_c_str(" ", arglist)
 
     _cFMS_diag_send_complete(*arglist)
@@ -123,102 +145,22 @@ def send_complete(diag_field_id: int) -> str:
     return err_msg.value.decode("utf-8")
 
 
-def set_field_init_time(
-    year: int,
-    month: int,
-    day: int,
-    hour: int,
-    minute: int,
-    second: int = None,
-    tick: int = None,
-) -> str:
-
-    """
-    Sets the time type in cFMS that represents the
-    field initial time.  This time is used when registering
-    a diag field
-    """
-
-    arglist = []
-    set_c_int(year, arglist)
-    set_c_int(month, arglist)
-    set_c_int(day, arglist)
-    set_c_int(hour, arglist)
-    set_c_int(minute, arglist)
-    set_c_int(second, arglist)
-    set_c_int(tick, arglist)
-    err_msg = set_c_str(" ", arglist)
-
-    _cFMS_diag_set_field_init_time(*arglist)
-
-    return err_msg.value.decode("utf-8")
-
-
-def set_field_timestep(
-    diag_field_id: int,
-    dseconds: int,
-    ddays: int = None,
-    dticks: int = None,
-) -> str:
-
-    """
-    Sets the timestep between each send_data
-    The timestep is saved as a time type in cFMS and is
-    used to advance field time
-    """
-
-    arglist = []
-    set_c_int(diag_field_id, arglist)
-    set_c_int(dseconds, arglist)
-    set_c_int(ddays, arglist)
-    set_c_int(dticks, arglist)
-    err_msg = set_c_str(" ", arglist)
-
-    _cFMS_diag_set_field_timestep(*arglist)
-
-    return err_msg.value.decode("utf-8")
-
-
-def advance_field_time(diag_field_id: int):
-
-    """
-    Updates the current field time by advancing
-    the current field time with the field timestep
-    set with diag_manager.set_field_timestep
-    """
-
-    arglist = []
-    set_c_int(diag_field_id, arglist)
-
-    _cFMS_diag_advance_field_time(*arglist)
-
-
 def set_time_end(
-    year: int = None,
-    month: int = None,
-    day: int = None,
-    hour: int = None,
-    minute: int = None,
-    second: int = None,
-    tick: int = None,
+    time_end: datetime,
 ):
 
     """
-    Sets the time type representing the field end time
-    in cFMS.  This time must be set before calling
-    diag_manager.end()
+    Sets the end time for the diag manager.
     """
-
     arglist = []
-    set_c_int(year, arglist)
-    set_c_int(month, arglist)
-    set_c_int(day, arglist)
-    set_c_int(hour, arglist)
-    set_c_int(minute, arglist)
-    set_c_int(second, arglist)
-    set_c_int(tick, arglist)
+    set_c_int(time_end.year, arglist)
+    set_c_int(time_end.month, arglist)
+    set_c_int(time_end.day, arglist)
+    set_c_int(time_end.hour, arglist)
+    set_c_int(time_end.minute, arglist)
+    set_c_int(time_end.second, arglist)
+    set_c_int(0, arglist) # assumes no ticks
     err_msg = set_c_str(" ", arglist)
-
     _cFMS_diag_set_time_end(*arglist)
 
 
@@ -294,6 +236,8 @@ def register_field_array(
     volume: int = None,
     realm: str = None,
     multiple_send_data: bool = None,
+    init_time: datetime = None,
+    ticks_per_second: int = 0,
 ) -> int:
 
     """
@@ -321,12 +265,23 @@ def register_field_array(
         while len(axes) < 5:
             axes.append(0)
 
+    int_time = []
+    if init_time is not None:
+        int_time.append(init_time.year)
+        int_time.append(init_time.month)
+        int_time.append(init_time.day)
+        int_time.append(init_time.hour)
+        int_time.append(init_time.minute)
+        int_time.append(init_time.second)
+        int_time.append(ticks_per_second)
+
     arglist = []
     set_c_str(module_name, arglist)
     set_c_str(field_name, arglist)
     set_list(axes, np.int32, arglist)
     set_c_str(long_name, arglist)
     set_c_str(units, arglist)
+    set_list(int_time, np.int32, arglist)
     if dtype == "float32":
         set_c_float(missing_value, arglist)
     else:
@@ -361,13 +316,12 @@ def register_field_scalar(
     volume: int = None,
     realm: str = None,
     multiple_send_data: bool = None,
+    init_time: datetime = None,
+    ticks_per_second: int = 0,
 ) -> int:
 
     """
     Registers scalar fields
-    The field initial time must be set with
-    diag_manager.set_field_init_time before calling
-    this method
     """
 
     try:
@@ -383,11 +337,22 @@ def register_field_scalar(
     check_str(standard_name, 64, whoami)
     check_str(realm, 64, whoami)
 
+    int_time = []
+    if init_time is not None:
+        int_time.append(init_time.year)
+        int_time.append(init_time.month)
+        int_time.append(init_time.day)
+        int_time.append(init_time.hour)
+        int_time.append(init_time.minute)
+        int_time.append(init_time.second)
+        int_time.append(ticks_per_second)
+
     arglist = []
     set_c_str(module_name, arglist)
     set_c_str(field_name, arglist)
     set_c_str(long_name, arglist)
     set_c_str(units, arglist)
+    set_list(int_time, np.int32, arglist)
     set_c_str(standard_name, arglist)
     if dtype == "float32":
         set_c_float(missing_value, arglist)
@@ -405,7 +370,11 @@ def register_field_scalar(
 
 
 def send_data(
-    diag_field_id: int, field: NDArray, convert_cf_order: bool = True
+    diag_field_id: int,
+    field: NDArray,
+    convert_cf_order: bool = True,
+    time: datetime = None,
+    ticks: int = 0,
 ) -> bool:
 
     """
@@ -425,6 +394,15 @@ def send_data(
                 f"ndim={field.ndim} and type {field.dtype} not supported"
             )
         )
+    int_time = []
+    if time is not None:
+        int_time.append(time.year)
+        int_time.append(time.month)
+        int_time.append(time.day)
+        int_time.append(time.hour)
+        int_time.append(time.minute)
+        int_time.append(time.second)
+        int_time.append(ticks)
 
     arglist = []
     set_c_int(diag_field_id, arglist)
@@ -432,6 +410,7 @@ def send_data(
     set_array(field, arglist)
     err_msg = set_c_str(" ", arglist)
     set_c_bool(convert_cf_order, arglist)
+    set_list(int_time, np.int32, arglist)
 
     return cfms_diag_send_data(*arglist)
 
@@ -452,13 +431,9 @@ def _init_constants():
 
 def _init_functions():
 
-    global _c_diag_manager_is_initialized
     global _cFMS_diag_end
     global _cFMS_diag_init
     global _cFMS_diag_send_complete
-    global _cFMS_diag_set_field_init_time
-    global _cFMS_diag_set_field_timestep
-    global _cFMS_diag_advance_field_time
     global _cFMS_diag_set_time_end
     global _cFMS_diag_axis_init_cfloat
     global _cFMS_diag_axis_init_cdouble
@@ -483,13 +458,9 @@ def _init_functions():
 
     _functions.define(_lib)
 
-    _c_diag_manager_is_initialized = _lib.c_diag_manager_is_initialized
     _cFMS_diag_end = _lib.cFMS_diag_end
     _cFMS_diag_init = _lib.cFMS_diag_init
     _cFMS_diag_send_complete = _lib.cFMS_diag_send_complete
-    _cFMS_diag_set_field_init_time = _lib.cFMS_diag_set_field_init_time
-    _cFMS_diag_set_field_timestep = _lib.cFMS_diag_set_field_timestep
-    _cFMS_diag_advance_field_time = _lib.cFMS_diag_advance_field_time
     _cFMS_diag_set_time_end = _lib.cFMS_diag_set_time_end
     _cFMS_diag_axis_init_cfloat = _lib.cFMS_diag_axis_init_cfloat
     _cFMS_diag_axis_init_cdouble = _lib.cFMS_diag_axis_init_cdouble

--- a/pyfms/py_diag_manager/diag_manager.py
+++ b/pyfms/py_diag_manager/diag_manager.py
@@ -1,9 +1,8 @@
+from datetime import datetime, timedelta
 from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-
-from datetime import datetime, timedelta
 
 from pyfms.py_diag_manager import _functions
 from pyfms.utils.ctypes_utils import (
@@ -70,7 +69,7 @@ def end(end_time: datetime):
     int_time.append(end_time.hour)
     int_time.append(end_time.minute)
     int_time.append(end_time.second)
-    int_time.append(0) # ticks
+    int_time.append(0)  # ticks
     set_list(int_time, np.int32, arglist)
     _cFMS_diag_end(*arglist)
 
@@ -105,7 +104,7 @@ def init(
         int_time.append(time_init.hour)
         int_time.append(time_init.minute)
         int_time.append(time_init.second)
-        int_time.append(0) # ticks
+        int_time.append(0)  # ticks
     else:
         int_time = None
     set_list(int_time, np.int32, arglist)
@@ -159,7 +158,7 @@ def set_time_end(
     set_c_int(time_end.hour, arglist)
     set_c_int(time_end.minute, arglist)
     set_c_int(time_end.second, arglist)
-    set_c_int(0, arglist) # assumes no ticks
+    set_c_int(0, arglist)  # assumes no ticks
     err_msg = set_c_str(" ", arglist)
     _cFMS_diag_set_time_end(*arglist)
 

--- a/pyfms/py_diag_manager/diag_manager.py
+++ b/pyfms/py_diag_manager/diag_manager.py
@@ -134,8 +134,6 @@ def send_complete(timestep: timedelta, ticks: int = 0) -> str:
     int_time.append(dtime.second)
     int_time.append(ticks)
 
-    print(f"send complete timestep:{timestep}\ndtime:{dtime}")
-
     set_list(int_time, np.int32, arglist)
     err_msg = set_c_str(" ", arglist)
 

--- a/pyfms/utils/ctypes_utils.py
+++ b/pyfms/utils/ctypes_utils.py
@@ -82,10 +82,14 @@ def set_array(arg: npt.ArrayLike | None, arglist: list) -> npt.ArrayLike | None:
     if arg is None:
         return setNone(arglist)
 
-    if not arg.flags["C"]:
-        arglist.append(np.ascontiguousarray(arg))
-    else:
+    try:
+        if not arg.flags["C"]:
+            arglist.append(np.ascontiguousarray(arg))
+        else:
+            arglist.append(arg)
+    except AttributeError:
         arglist.append(arg)
+
     return arg
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ class CustomBuild(build):
         build.run(self)
 
 
-test_requirements = ["pytest", "pytest-subtests", "coverage"]
+test_requirements = ["pytest", "pytest-subtests", "coverage", "dask"]
 develop_requirements = test_requirements + ["pre-commit"]
 
 extras_requires = {

--- a/tests/py_diag_manager/test_diag_manager.py
+++ b/tests/py_diag_manager/test_diag_manager.py
@@ -1,10 +1,9 @@
 import os
+from datetime import datetime, timedelta
 
 import numpy as np
 
 import pyfms
-
-from datetime import datetime, timedelta
 
 
 def test_send_data():
@@ -100,9 +99,9 @@ def test_send_data():
     """
     set up our start/end times and timestep
     """
-    start_time = datetime(2,1,1,1,1,1)
+    start_time = datetime(2, 1, 1, 1, 1, 1)
     timestep = timedelta(seconds=3600)
-    end_time = datetime(2,1,2,1,1,1)
+    end_time = datetime(2, 1, 2, 1, 1, 1)
 
     """
     register diag field var3

--- a/tests/py_diag_manager/test_diag_manager.py
+++ b/tests/py_diag_manager/test_diag_manager.py
@@ -2,33 +2,23 @@ import os
 from datetime import datetime, timedelta
 
 import numpy as np
+import xarray as xr
 
 import pyfms
 
 
 def test_send_data():
 
-    nx = 8
-    ny = 8
+    nx = 32
+    ny = 32
     nz = 2
-
-    var2 = np.empty(shape=(nx, ny), dtype=np.float32)
-    for i in range(nx):
-        for j in range(ny):
-            var2[i][j] = i * 10.0 + j * 1.0
-
-    var3 = np.empty(shape=(nx, ny, nz), dtype=np.float32)
-    for i in range(nx):
-        for j in range(ny):
-            for k in range(nz):
-                var3[i][j][k] = i * 100 + j * 10 + k * 1
 
     pyfms.fms.init(calendar_type=pyfms.fms.NOLEAP)
 
     pe = pyfms.mpp.pe()
     npes = pyfms.mpp.npes()
 
-    global_indices = [0, (nx - 1), 0, (ny - 1)]
+    global_indices = [0, nx-1, 0, ny-1]
     layout = [1, npes]
     io_layout = [1, 1]
 
@@ -41,12 +31,25 @@ def test_send_data():
         io_layout=io_layout,
     )
 
+    var2_global = np.empty(shape=(nx,ny), dtype=np.float32)
+    var3_global = np.empty(shape=(nx,ny,nz), dtype=np.float32)
+    for i in range(nx):
+        for j in range(ny):
+            var2_global[i][j] = i * 10.0 + j * 1.0
+    for i in range(nx):
+        for j in range(ny):
+            for k in range(nz):
+                var3_global[i][j][k] = i * 100 + j * 10 + k * 1
+
+    # fortran includes the last element in array slices (ie array[isc:iec] includes array[iec])
+    # python does not, so need to increment.
+    var2 = var2_global[domain.isc:domain.iec+1,domain.jsc:domain.jec+1]
+    var3 = var3_global[domain.isc:domain.iec+1,domain.jsc:domain.jec+1,:]
+
     """
     diag manager init
     """
-
     pyfms.diag_manager.init(diag_model_subset=pyfms.diag_manager.DIAG_ALL)
-
     pyfms.mpp_domains.set_current_domain(domain_id=domain.domain_id)
 
     """
@@ -101,7 +104,8 @@ def test_send_data():
     """
     start_time = datetime(2, 1, 1, 1, 1, 1)
     timestep = timedelta(seconds=3600)
-    end_time = datetime(2, 1, 2, 1, 1, 1)
+    ntime = 8
+    end_time = start_time + (timestep * ntime)
 
     """
     register diag field var3
@@ -143,33 +147,46 @@ def test_send_data():
     """
     send data
     """
-
-    ntime = 24
     curr_time = start_time
+    do_send_data = True 
     for itime in range(ntime):
         curr_time = curr_time + timestep
-        print(f"sending data for time: {curr_time}")
-        var3 = -var3
-        success = pyfms.diag_manager.send_data(
-            diag_field_id=id_var3,
-            field=var3,
-            time=curr_time,
-        )
-        assert success
+        print(f"(not) sending data for time: {curr_time}")
+        if do_send_data:
 
-        var2 = -var2
-        success = pyfms.diag_manager.send_data(
-            diag_field_id=id_var2,
-            field=var2,
-            time=curr_time,
-        )
-        assert success
+            success = pyfms.diag_manager.send_data(
+                diag_field_id=id_var3,
+                field=var3,
+                time=curr_time,
+            )
+            assert success
+            # skip this one for now
+            success = pyfms.diag_manager.send_data(
+                diag_field_id=id_var2,
+                field=var2,
+                time=curr_time,
+            )
+            assert success
         pyfms.diag_manager.send_complete(timestep)
 
     pyfms.diag_manager.end(end_time)
     pyfms.fms.end()
 
-    assert os.path.isfile("test_send_data.nc")
+    """
+    check our output is correct
+    """
+    if pyfms.mpp.pe() == pyfms.mpp.root_pe():
+        assert os.path.isfile("test_send_data.nc")
+        ds = xr.open_mfdataset("test_send_data.nc", decode_times=True)
+        assert "var2_avg" in ds
+        assert "var3_avg" in ds
+        assert ds["var2_avg"].dims == ("time", "y", "x")
+        assert ds["var3_avg"].dims == ("time", "z", "y", "x" )
+        assert ds["time"].dims == ("time",)
+        assert ds["time"].shape == (ntime,)
+        for i in range(ntime):
+            np.testing.assert_array_equal(ds["var2_avg"].values[i,:,:], np.transpose(var2_global))
+            np.testing.assert_array_equal(ds["var3_avg"].values[i,:,:,:], np.transpose(var3_global))
 
 
 if __name__ == "__main__":

--- a/tests/py_diag_manager/test_diag_manager.py
+++ b/tests/py_diag_manager/test_diag_manager.py
@@ -18,7 +18,7 @@ def test_send_data():
     pe = pyfms.mpp.pe()
     npes = pyfms.mpp.npes()
 
-    global_indices = [0, nx-1, 0, ny-1]
+    global_indices = [0, nx - 1, 0, ny - 1]
     layout = [1, npes]
     io_layout = [1, 1]
 
@@ -31,8 +31,8 @@ def test_send_data():
         io_layout=io_layout,
     )
 
-    var2_global = np.empty(shape=(nx,ny), dtype=np.float32)
-    var3_global = np.empty(shape=(nx,ny,nz), dtype=np.float32)
+    var2_global = np.empty(shape=(nx, ny), dtype=np.float32)
+    var3_global = np.empty(shape=(nx, ny, nz), dtype=np.float32)
     for i in range(nx):
         for j in range(ny):
             var2_global[i][j] = i * 10.0 + j * 1.0
@@ -43,8 +43,8 @@ def test_send_data():
 
     # fortran includes the last element in array slices (ie array[isc:iec] includes array[iec])
     # python does not, so need to increment.
-    var2 = var2_global[domain.isc:domain.iec+1,domain.jsc:domain.jec+1]
-    var3 = var3_global[domain.isc:domain.iec+1,domain.jsc:domain.jec+1,:]
+    var2 = var2_global[domain.isc : domain.iec + 1, domain.jsc : domain.jec + 1]
+    var3 = var3_global[domain.isc : domain.iec + 1, domain.jsc : domain.jec + 1, :]
 
     """
     diag manager init
@@ -148,7 +148,7 @@ def test_send_data():
     send data
     """
     curr_time = start_time
-    do_send_data = True 
+    do_send_data = True
     for itime in range(ntime):
         curr_time = curr_time + timestep
         print(f"(not) sending data for time: {curr_time}")
@@ -181,12 +181,16 @@ def test_send_data():
         assert "var2_avg" in ds
         assert "var3_avg" in ds
         assert ds["var2_avg"].dims == ("time", "y", "x")
-        assert ds["var3_avg"].dims == ("time", "z", "y", "x" )
+        assert ds["var3_avg"].dims == ("time", "z", "y", "x")
         assert ds["time"].dims == ("time",)
         assert ds["time"].shape == (ntime,)
         for i in range(ntime):
-            np.testing.assert_array_equal(ds["var2_avg"].values[i,:,:], np.transpose(var2_global))
-            np.testing.assert_array_equal(ds["var3_avg"].values[i,:,:,:], np.transpose(var3_global))
+            np.testing.assert_array_equal(
+                ds["var2_avg"].values[i, :, :], np.transpose(var2_global)
+            )
+            np.testing.assert_array_equal(
+                ds["var3_avg"].values[i, :, :, :], np.transpose(var3_global)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -89,7 +89,7 @@ remove_input $test
 run_test "pytest $flags py_diag_manager/test_generate_files.py"
 
 run_test "mpirun -n 1 pytest $flags py_diag_manager/test_diag_manager.py"
-run_test "mpirun -n 4 pytest $flags py_diag_manager/test_diag_manager.py"
+run_test "mpirun --oversubscribe -n 4 pytest $flags py_diag_manager/test_diag_manager.py"
 
 run_test "pytest $flags utils/test_constants.py"
 run_test "pytest $flags utils/test_get_grid_area.py"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -87,7 +87,9 @@ remove_input $test
 # remove_input $test
 
 run_test "pytest $flags py_diag_manager/test_generate_files.py"
+
 run_test "mpirun -n 1 pytest $flags py_diag_manager/test_diag_manager.py"
+run_test "mpirun -n 4 pytest $flags py_diag_manager/test_diag_manager.py"
 
 run_test "pytest $flags utils/test_constants.py"
 run_test "pytest $flags utils/test_get_grid_area.py"


### PR DESCRIPTION
**Description**
Updates to go along with https://github.com/NOAA-GFDL/cFMS/pull/29. Removes some routines and adds arguments to pass in the times directly. Also adds a unit test with 4 ranks and some output checks.

I tried to use the python datetime or timedelta types to simplify things from the python side, they get converted to ints prior to the cFMS calls. FMS time_types can do dates or intervals, so the conversion from datetime is kinda weird and might need additional changes later on.

**How Has This Been Tested?**
amd box with conda-installed dependencies (gcc 15, mpich 4.3.2, python 3.11.14).

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] New check tests, if applicable, are included
