### PR TITLE
Move `pytest.ini` into `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,11 @@ source_pkgs = ["pyfms"]
 exclude = ["docs"]
 extend-ignore = ["E203","E501","W293","W503","E302","E203","F841", "F401", "F824", "B007"]
 max-line-length = "88"
+
+[tool.pytest]
+markers = [
+    "create",  # mark a test as create.
+    "remove",  # mark test as remove.
+    "parallel",  #  mark test as parallel.
+    "convert_cf_order",  # mark test to transpose data from C to F ordered
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-markers =
-    create: mark a test as create.
-    remove: mark test as remove.
-    parallel:  mark test as parallel.
-    convert_cf_order: mark test to transpose data from C to F ordered


### PR DESCRIPTION
**Description**

This PR moves the contents of `pytest.ini` into `pyproject.toml` where all project configuration can be centralized. This is a follow-up from https://github.com/NOAA-GFDL/pyFMS/pull/39, which introduced `pyproject.toml` in the first place.

**How Has This Been Tested?**

CI will complain if something were not okay anymore.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
