### PR TITLE
ci: update GHA workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,20 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v7
+      - name: Setup Python
+        uses: actions/setup-python@v6
         with:
-          submodules: 'recursive'
-      - name: Step Python
-        uses: actions/setup-python@v4.6.0
-        with:
-          python-version: '3.12.13'
+          python-version: '3.12'
       - name: Install OpenMPI
         run: |
-          sudo apt-get update && sudo apt-get install libopenmpi-dev netcdf-bin libnetcdf-dev libnetcdff-dev nco libyaml-dev diffutils
+          sudo apt-get update
+          sudo apt-get install libopenmpi-dev netcdf-bin libnetcdf-dev libnetcdff-dev nco libyaml-dev diffutils
       - name: Install Python packages
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install .[dev]
+        run: pip install .[dev]
       - name: Run lint via pre-commit
-        run: |
-          pre-commit run --all-files
+        run: pre-commit run --all-files

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -12,20 +12,18 @@ jobs:
     env:
       LD_LIBRARY_PATH:
     steps:
-      - name: Checkout out hash that triggered CI
-        uses: actions/checkout@v4
+      - name: Checkout out repository
+        uses: actions/checkout@v7
+      - name: Setup Python
+        uses: actions/setup-python@v6
         with:
-          submodules: 'recursive'
-      - name: Step Python
-        uses: actions/setup-python@v4.6.0
-        with:
-          python-version: '3.12.13'
+          python-version: '3.12'
       - name: Install Dependencies for Build
         run: |
-          sudo apt-get update && sudo apt-get install libopenmpi-dev netcdf-bin libnetcdf-dev libnetcdff-dev nco libyaml-dev diffutils
-      - name: install packages
-        run: |
-          pip install -v .[test]
+          sudo apt-get update
+          sudo apt-get install libopenmpi-dev netcdf-bin libnetcdf-dev libnetcdff-dev nco libyaml-dev diffutils
+      - name: Install Python packages
+        run: pip install -v .[test]
       - name: run tests
         run: |
           cd tests


### PR DESCRIPTION
**Description**

GitHub Actions workflows are emitting warnings because of outdated dependencies. `actions/checkout` and `actions/setup-python` need to be updated because they were built to run on Node.js 20, which isn't available anymore. The actions are forced to run on Node.js 24 now.

More information can be found here: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**How Has This Been Tested?**

If something is wrong, CI will complain - otherwise all good.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
