### PR TITLE
ci: update pre-commit hooks to recent versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: Install Python packages
         run: pip install .[dev]
       - name: Run lint via pre-commit
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 26.5.1
     hooks:
       - id: black
         additional_dependencies: ["click==8.0.4"]
@@ -15,7 +15,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
       - id: check-toml
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,15 @@ default_language_version:
   python: python3
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 26.5.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
     hooks:
       - id: black
-        additional_dependencies: ["click==8.0.4"]
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 8.0.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/pyfms/cfms.py
+++ b/pyfms/cfms.py
@@ -9,7 +9,6 @@ _lib = None
 
 
 def init(libpath: str = None):
-
     """
     Initializes the pyfms package by
     setting the cFMS library in all modules
@@ -47,7 +46,6 @@ def init(libpath: str = None):
 
 
 def lib() -> type[ctypes.CDLL]:
-
     """
     Returns the currently used ctypes.CDLL
     cFMS object
@@ -57,7 +55,6 @@ def lib() -> type[ctypes.CDLL]:
 
 
 def libpath() -> str:
-
     """
     Returns the library path of the currently
     used cFMS object

--- a/pyfms/py_data_override/_functions.py
+++ b/pyfms/py_data_override/_functions.py
@@ -4,7 +4,6 @@ import numpy as np
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/py_data_override/data_override.py
+++ b/pyfms/py_data_override/data_override.py
@@ -44,7 +44,6 @@ def init(
     land_domainUG_id: int = None,
     mode: int = None,
 ):
-
     """
     Users can specify the domains associated with each component with
     domain_ids generated from mpp_domains.define.  This id's correspond
@@ -82,7 +81,6 @@ def set_time(
     second: int = None,
     tick: int = None,
 ):
-
     """
     Sets the time type in cFMS.  The set time will be used to specify
     targeted time for temporal interpolation in FMS data_override
@@ -107,7 +105,6 @@ def override_scalar(
     dtype: str,
     data_index: int = None,
 ) -> np.float32 | np.float64:
-
     """
     pyfms.data_override.override_scalar
     Interpolates scalar variables
@@ -142,7 +139,6 @@ def override(
     je_in: int = None,
     convert_cf_order: bool = True,
 ) -> bool:
-
     """
     pyfms.data_override.override
     Interpolates data of c_float and c_double kind
@@ -179,7 +175,6 @@ def override(
 
 
 def _init_constants():
-
     """
     Initializes parameters used in data_override_init
     mode=CFLOAT_MODE initializes data_override in 32-bit mode for real variables
@@ -235,7 +230,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets the library path and library object
     Initializes constants

--- a/pyfms/py_diag_manager/_functions.py
+++ b/pyfms/py_diag_manager/_functions.py
@@ -10,7 +10,6 @@ C = "C_CONTIGUOUS"
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/py_diag_manager/diag_manager.py
+++ b/pyfms/py_diag_manager/diag_manager.py
@@ -54,6 +54,7 @@ _cFMS_register_diag_field_arrays = {}
 _cFMS_register_diag_field_scalars = {}
 _cFMS_diag_send_datas = {}
 
+
 # TODO: ideally, end_time would be optional here since it can be set prior to the end of a run via set_time_end.
 # FMS usage typically sets the end time with diag_manager_end instead, so leaving this as is for now
 def end(end_time: datetime):
@@ -78,7 +79,6 @@ def init(
     diag_model_subset: int = None,
     time_init: datetime = None,
 ) -> str:
-
     """
     Initializes diag_manager
 
@@ -116,7 +116,6 @@ def init(
 
 
 def send_complete(timestep: timedelta, ticks: int = 0) -> str:
-
     """
     Finishes diag manager operations for this timestep; performing any reductions and writing to the file(s).
     This function must be called after all data for a given timestep has been sent via send_data.
@@ -145,7 +144,6 @@ def send_complete(timestep: timedelta, ticks: int = 0) -> str:
 def set_time_end(
     time_end: datetime,
 ):
-
     """
     Sets the end time for the diag manager.
     """
@@ -177,7 +175,6 @@ def axis_init(
     domain_position: int = None,
     not_xy: bool = None,
 ) -> int:
-
     """
     Initializes the diag_axis
     not_xy = True must be specified when initializing an axis
@@ -236,7 +233,6 @@ def register_field_array(
     init_time: datetime = None,
     ticks_per_second: int = 0,
 ) -> int:
-
     """
     Registers multi-dimensional fields
     The field initial time must be set with
@@ -316,7 +312,6 @@ def register_field_scalar(
     init_time: datetime = None,
     ticks_per_second: int = 0,
 ) -> int:
-
     """
     Registers scalar fields
     """
@@ -373,7 +368,6 @@ def send_data(
     time: datetime = None,
     ticks: int = 0,
 ) -> bool:
-
     """
     Send field data to diag_manager that will be outputted to a diagnostic file
     The users should set the field time by advancing current time with
@@ -413,7 +407,6 @@ def send_data(
 
 
 def _init_constants():
-
     """
     Retrieves and assigns diag_manager related parameters
     from FMS
@@ -518,7 +511,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyfms/py_fms/_functions.py
+++ b/pyfms/py_fms/_functions.py
@@ -2,7 +2,6 @@ from ctypes import POINTER, c_bool, c_char_p, c_int
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/py_fms/fms.py
+++ b/pyfms/py_fms/fms.py
@@ -27,7 +27,6 @@ def init(
     nnest_domain: int = None,
     calendar_type: int = None,
 ):
-
     """
     Calls cfms_init which calls fms_init, calls time_manager_init,
     sets the calendar type in time_manager, and sets the total
@@ -50,7 +49,6 @@ def init(
 
 
 def end():
-
     """
     Calls mpp_error
     Termination routine for the fms module. It also calls destructor routines
@@ -61,7 +59,6 @@ def end():
 
 
 def module_is_initialized():
-
     """
     returns module_is_initialized variable from c_fms_mod
     """
@@ -70,7 +67,6 @@ def module_is_initialized():
 
 
 def _init_constants():
-
     """
     Initializes parameters for mpp.error (mpp_error)
     and parameters to set the calendar type (these values
@@ -106,7 +102,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyfms/py_horiz_interp/_functions.py
+++ b/pyfms/py_horiz_interp/_functions.py
@@ -10,7 +10,6 @@ C = "C_CONTIGUOUS"
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/py_horiz_interp/horiz_interp.py
+++ b/pyfms/py_horiz_interp/horiz_interp.py
@@ -46,7 +46,6 @@ _cFMS_horiz_interp_base_dict = {}
 
 
 def get_maxxgrid() -> np.int32:
-
     """
     Defines the maximum number of exchange cells
     that can be created by create_xgrid_*
@@ -62,7 +61,6 @@ def create_xgrid_2dx2d_order1(
     lat_tgt: npt.NDArray[np.float64],
     mask_src: npt.NDArray[np.float64],
 ) -> dict:
-
     """
     Creates the exchange grid that can be used
     for first order conservative interpolation
@@ -100,7 +98,6 @@ def create_xgrid_2dx2d_order1(
 
 
 def init(ninterp: int = None):
-
     """
     Initializes horiz_interp in FMS
     """
@@ -112,7 +109,6 @@ def init(ninterp: int = None):
 
 
 def end():
-
     """
     Calls cFMS_horiz_interp_end to deallocate interp
     """
@@ -121,7 +117,6 @@ def end():
 
 
 def module_is_initialized():
-
     """
     Returns module_is_initialized in c_horiz_interp_mod
     """
@@ -441,7 +436,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyfms/py_mpp/_mpp_domains_functions.py
+++ b/pyfms/py_mpp/_mpp_domains_functions.py
@@ -10,7 +10,6 @@ C = "C_CONTIGUOUS"
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/py_mpp/_mpp_functions.py
+++ b/pyfms/py_mpp/_mpp_functions.py
@@ -10,7 +10,6 @@ C = "C_CONTIGUOUS"
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/py_mpp/mpp.py
+++ b/pyfms/py_mpp/mpp.py
@@ -158,7 +158,6 @@ def declare_pelist(
     pelist: list[int],
     name: str = None,
 ) -> int:
-
     """
     This method is written specifically to accommodate a MPI restriction
     that requires a parent communicator to create a child communicator.
@@ -189,7 +188,6 @@ def declare_pelist(
 
 
 def error(errortype: int, errormsg: str = None):
-
     """
     Calls mpp_error.  An errortype of FATAL will
     call for MPI synchronization and termination
@@ -210,7 +208,6 @@ def get_current_pelist(
     get_name: bool = False,
     get_commID: bool = False,
 ) -> Any:
-
     """
     Returns the current pelist.
     npes specifies the length of the pelist and must be
@@ -237,7 +234,6 @@ def get_current_pelist(
 
 
 def npes() -> int:
-
     """
     Returns: number of pes in use
     """
@@ -246,7 +242,6 @@ def npes() -> int:
 
 
 def pe() -> int:
-
     """
     Returns: pe number of calling pe
     """
@@ -255,7 +250,6 @@ def pe() -> int:
 
 
 def root_pe() -> int:
-
     """
     Returns the root pe in the current pelist
     """
@@ -263,7 +257,6 @@ def root_pe() -> int:
 
 
 def set_current_pelist(pelist: list[int] = None, no_sync: bool = None):
-
     """
     Sets the current pelist
     """
@@ -338,7 +331,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyfms/py_mpp/mpp_domains.py
+++ b/pyfms/py_mpp/mpp_domains.py
@@ -90,7 +90,6 @@ def get_compute_domain(
     whalo: int = None,
     shalo: int = None,
 ) -> dict:
-
     """
     Queries and returns a dictionary of compute domain indices and
     compute domain size associated with domain_id.  The returned
@@ -139,7 +138,6 @@ def get_data_domain(
     whalo: int = None,
     shalo: int = None,
 ) -> dict:
-
     """
     Queries and returns a dictionary of data domain indices and
     data domain size associated with domain_id.  The returned
@@ -206,7 +204,6 @@ def define_domains(
     x_cyclic_offset: int = None,
     y_cyclic_offset: int = None,
 ) -> type(Domain):
-
     """
     Creates a domain.  Automatically queries the newly formed
     compute and data domains and returns a pyDomain object with
@@ -272,7 +269,6 @@ def define_domains(
 
 
 def define_io_domain(io_layout: list[int], domain_id: int):
-
     """
     Defines the io domain for domain with domain_id
     """
@@ -285,7 +281,6 @@ def define_io_domain(io_layout: list[int], domain_id: int):
 
 
 def define_layout(global_indices: list[int], ndivs: int) -> list:
-
     """
     Defines the layout associated with a domain decomposition
     """
@@ -317,7 +312,6 @@ def define_nest_domains(
     extra_halo: int = None,
     name: str = None,
 ) -> int:
-
     """
     Defines the nest domain where the the parent domain has domain_id
     Returns a nest_domain_id corresponding to the FmsMppDomainsNestDomain
@@ -353,7 +347,6 @@ def define_cubic_mosaic(
     halo: int = None,
     use_memsize: bool = None,
 ) -> int:
-
     """
     Defines a cubic mosaic domain based on the
     given global indices and layout.
@@ -374,7 +367,6 @@ def define_cubic_mosaic(
 
 
 def domain_is_initialized(domain_id: int) -> bool:
-
     """
     Returns True if domain with domain_id has been initialized;
     else, returns False
@@ -387,7 +379,6 @@ def domain_is_initialized(domain_id: int) -> bool:
 
 
 def get_domain_name(domain_id: int) -> str:
-
     """
     Returns the domain name associated with domain_id
     """
@@ -402,7 +393,6 @@ def get_domain_name(domain_id: int) -> str:
 
 
 def get_layout(domain_id: int) -> list[int]:
-
     """
     Returns the layout associated with domain_id
     """
@@ -417,7 +407,6 @@ def get_layout(domain_id: int) -> list[int]:
 
 
 def get_domain_pelist(domain_id: int) -> list[int]:
-
     """
     Returns the pelist associated with domain_id
     """
@@ -447,7 +436,6 @@ def set_compute_domain(
     whalo: int = None,
     shalo: int = None,
 ):
-
     """
     Overrides the default compute domain set with define_domains
     for domain_id.
@@ -475,7 +463,6 @@ def set_compute_domain(
 
 
 def set_current_domain(domain_id: int):
-
     """
     Sets current_domain in cFMS to be the domain with domain_id
     This function is to be used internally in pyFMS
@@ -501,7 +488,6 @@ def set_data_domain(
     whalo: int = None,
     shalo: int = None,
 ):
-
     """
     Overrides the default data domain set with define_domains
     for domain_id
@@ -540,7 +526,6 @@ def set_global_domain(
     whalo: int = None,
     shalo: int = None,
 ):
-
     """
     Overrides the default global domain set with define_domains
     for domain_id
@@ -575,7 +560,6 @@ def update_domains(
     tile_count: int = None,
     convert_cf_order: bool = True,
 ):
-
     """
     Updates the field values for the halo regions
     in the data domain associated with domain_id
@@ -657,7 +641,6 @@ def vector_update_domains(
 
 
 def _init_constants():
-
     """
     Retrieves and assigns mpp_domain related parameters
     from FMS
@@ -818,7 +801,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyfms/utils/_grid_utils_functions.py
+++ b/pyfms/utils/_grid_utils_functions.py
@@ -8,7 +8,6 @@ C = "C_CONTIGUOUS"
 
 
 def define(lib):
-
     """
     Sets the restype and argtypes of all
     public functions in cFMS

--- a/pyfms/utils/constants.py
+++ b/pyfms/utils/constants.py
@@ -57,7 +57,6 @@ RADCON_MKS = None
 
 
 def _init_constants():
-
     """
     Initializes all FMS constants
     All constants are initialized as np.float64 kind
@@ -122,7 +121,6 @@ def _init_constants():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyfms/utils/ctypes_utils.py
+++ b/pyfms/utils/ctypes_utils.py
@@ -111,7 +111,6 @@ def check_str(arg: str, length: int, whoami: str):
 
 
 class NDPOINTERi32:
-
     """
     wrapper to np.ctypeslib.ndpointer for ints
     to accept None as function argument
@@ -128,7 +127,6 @@ class NDPOINTERi32:
 
 
 class NDPOINTERf:
-
     """
     wrapper to np.ctypeslib.ndpointer for floats
     to accept None as function argument
@@ -145,7 +143,6 @@ class NDPOINTERf:
 
 
 class NDPOINTERd:
-
     """
     wrapper to np.ctypeslib.ndpointer for doubles
     to accept None as function argument
@@ -165,7 +162,6 @@ ctypes_dict = {np.int32: c_int, np.float32: c_float, np.float64: c_double}
 
 
 class NDPOINTER:
-
     """
     Wrapper to np.ctypeslib.ndpointer for doubles
     to accept None as function argument

--- a/pyfms/utils/grid_utils.py
+++ b/pyfms/utils/grid_utils.py
@@ -18,7 +18,6 @@ def get_grid_area(
     lat: npt.NDArray[np.float64],
     convert_cf_order: bool = True,
 ) -> npt.NDArray[np.float64]:
-
     """
     Returns the cell areas of grids defined
     on lon and lat
@@ -59,7 +58,6 @@ def _init_functions():
 
 
 def _init(libpath: str, lib: Any):
-
     """
     Sets _libpath and _lib module variables associated
     with the loaded cFMS library.  This function is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ wheel.expand-macos-universal-tags = true
 CMAKE_GENERATOR = "Unix Makefiles"
 
 [tool.isort]
+profile = "black"
 line_length = "88"
 force_grid_wrap = "0"
 include_trailing_comma = "true"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,6 @@ import pyfms
 
 
 def test_library_loaded():
-
     """
     Test to ensure library loaded automatically
     """
@@ -13,7 +12,6 @@ def test_library_loaded():
 
 
 def test_share_same_library():
-
     """
     Test to ensure pyfms modules use the same
     ctypes CDLL library object
@@ -24,7 +22,6 @@ def test_share_same_library():
 
 @pytest.mark.xfail
 def test_library_load_fail():
-
     """
     Partial test to ensure the changelib function
     works


### PR DESCRIPTION
**Description**

This PR updates the dependencies configured in `.pre-commit-config.yaml` to recent versions. It looks like a default changed when updating the `black` formatter because afterwards some files got reformatted. Looks like whitespace-only change, so I wouldn't be worried.

**How Has This Been Tested?**

Running `pre-commit --all-files` locally. CI will enforce linting (as before).

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
