### PR TITLE
Document minimal `CMake` version and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyFMS
 
-The `pyFMS` package is a Python-C-Fortran interface (through the use of the `ctypes` package), for access to select methods from the Flexible Modeling System (`FMS`) developed by NOAA/GFDL (https://github.com/NOAA-GFDL/FMS.git).
+The `pyFMS` package is a Python-C-Fortran interface (through the use of the `ctypes` package), for access to select methods from the [Flexible Modeling System](https://github.com/NOAA-GFDL/FMS.git) (`FMS`) developed by NOAA/GFDL.
 
 ## Quickstart - bare metal
 
@@ -10,9 +10,10 @@ The build backend of `pyFMS` is `scikit-build-core`, which allows for the compil
 
 `pyFMS` requires:
 
-- GCC > 9.2
+- GCC > 9.2 (C and Fortran compiler)
 - MPI
 - Python 3.12
+- CMake >= 3.18
 
 To clone `pyFMS` from its GitHub repository:
 
@@ -34,8 +35,9 @@ pip install .[install_options]
 ```
 
 The available `install_options` are:
+
 - `test`
-- `dev` (which installs the `test` dependecies as well)
+- `dev` (which installs the `test` dependencies as well)
 - `extras` (which installs the `dev` dependencies as well)
 
 For developers we suggest installing with the editable flag `-e` and the verbose flag `-v`:

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -2,12 +2,12 @@
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# In applying this licence, ECMWF does not waive the privileges and immunities
-# granted to it by virtue of its status as an intergovernmental organisation nor
+# In applying this license, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organization nor
 # does it submit to any jurisdiction.
 
 # Try to find NetCDF includes and library.
-# Supports static and shared libaries and allows each component to be found in sepearte prefixes.
+# Supports static and shared libraries and allows each component to be found in separate prefixes.
 #
 # This module defines
 #

--- a/pyfms/cfms.py
+++ b/pyfms/cfms.py
@@ -49,7 +49,7 @@ def init(libpath: str = None):
 def lib() -> type[ctypes.CDLL]:
 
     """
-    returns the currently used ctypes.CDLL
+    Returns the currently used ctypes.CDLL
     cFMS object
     """
 
@@ -59,7 +59,7 @@ def lib() -> type[ctypes.CDLL]:
 def libpath() -> str:
 
     """
-    returns the library path of the currently
+    Returns the library path of the currently
     used cFMS object
     """
 

--- a/pyfms/py_field_manager/py_field_manager.py
+++ b/pyfms/py_field_manager/py_field_manager.py
@@ -45,7 +45,7 @@ class FieldTable:
     def get_var(self, module: str, varname: str) -> Dict:
         """
         When called will return dictionary related to variable matching `varname`
-        within module 'module', containg all current key:value pairs of the variable
+        within module 'module', containing all current key:value pairs of the variable
 
         Returns: Dictionary
         """

--- a/pyfms/py_horiz_interp/horiz_interp.py
+++ b/pyfms/py_horiz_interp/horiz_interp.py
@@ -102,7 +102,7 @@ def create_xgrid_2dx2d_order1(
 def init(ninterp: int = None):
 
     """
-    initializes horiz_interp in FMS
+    Initializes horiz_interp in FMS
     """
 
     arglist = []
@@ -123,7 +123,7 @@ def end():
 def module_is_initialized():
 
     """
-    returns module_is_initialized in c_horiz_interp_mod
+    Returns module_is_initialized in c_horiz_interp_mod
     """
 
     return _c_horiz_interp_is_initialized()

--- a/pyfms/utils/ctypes_utils.py
+++ b/pyfms/utils/ctypes_utils.py
@@ -167,7 +167,7 @@ ctypes_dict = {np.int32: c_int, np.float32: c_float, np.float64: c_double}
 class NDPOINTER:
 
     """
-    wrapper to np.ctypeslib.ndpointer for doubles
+    Wrapper to np.ctypeslib.ndpointer for doubles
     to accept None as function argument
     """
 


### PR DESCRIPTION
**Description**

This PR documents the minimal `CMake` version in the project's `README.md` and fixes a couple of typos in comments. This is a follow-up from https://github.com/NOAA-GFDL/pyFMS/pull/39, which introduced the `CMake`-based install.

**How Has This Been Tested?**

N/A

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas: N/A
- [ ] I have made corresponding changes to the documentation: N/A
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules: N/A
- [ ] New check tests, if applicable, are included: N/A
